### PR TITLE
Set the correct namespace for the GrantInterface

### DIFF
--- a/src/OAuth2/Client/Provider/IdentityProvider.php
+++ b/src/OAuth2/Client/Provider/IdentityProvider.php
@@ -70,7 +70,7 @@ abstract class IdentityProvider {
                 throw new \InvalidArgumentException('Unknown grant "'.$grant.'"');
             }
             $grant = new $grant;
-        } elseif ( ! $grant instanceof Grant\GrantInterface) {
+        } elseif ( ! $grant instanceof \OAuth2\Client\Grant\GrantInterface) {
             throw new \InvalidArgumentException($grant.' is not an instance of \OAuth2\Client\Grant\GrantInterface');
         }
 


### PR DESCRIPTION
Injecting an instance of a class that implements GrantInterface always failed because the namespace wasn't correctly specified.
