### PR TITLE
Fixed typo in authorization method call

### DIFF
--- a/src/League/OAuth2/Client/Provider/IdentityProvider.php
+++ b/src/League/OAuth2/Client/Provider/IdentityProvider.php
@@ -65,7 +65,7 @@ abstract class IdentityProvider {
 
     public function authorize($options = array())
     {
-        header('Location: ' . $this->getAuthorizeUrl($options));
+        header('Location: ' . $this->getAuthorizationUrl($options));
         exit;
     }
 


### PR DESCRIPTION
This PR fixes what I believe is a typo in the recent auth rename commits. Without this fix I'm getting:

```
 Call to undefined method League\OAuth2\Client\Provider\Google::getAuthorizeUrl() 
```

when attempting to redirect to the Google auth prompt.
