### PR TITLE
IdentityProvider.php: Explicit call to $grant->__toString

### DIFF
--- a/src/League/OAuth2/Client/Provider/IdentityProvider.php
+++ b/src/League/OAuth2/Client/Provider/IdentityProvider.php
@@ -85,7 +85,7 @@ abstract class IdentityProvider {
             'client_id'     => $this->clientId,
             'client_secret' => $this->clientSecret,
             'redirect_uri'  => $this->redirectUri,
-            'grant_type'    => $grant,
+            'grant_type'    => $grant->__toString(),
         );
 
         $requestParams = $grant->prepRequestParams($defaultParams, $params);


### PR DESCRIPTION
Explicit call to $grant->__toString.

The __toString method didn't seem to be triggered on setting the defaultParams array which then again threw an error in guzzle when it tried to validate the parameters. (Cannot use object of type League\OAuth2\Client\Grant\Authorizationcode as array) 

(Tested with PHP 5.4.12 on a windows machine)
