### PR TITLE
http_build_query params change as per issue#48

### DIFF
--- a/src/League/OAuth2/Client/Provider/IdentityProvider.php
+++ b/src/League/OAuth2/Client/Provider/IdentityProvider.php
@@ -70,7 +70,7 @@ abstract class IdentityProvider
             'approval_prompt' => 'auto'
         );
 
-        return $this->urlAuthorize().'?'.http_build_query($params);
+        return $this->urlAuthorize().'?'.http_build_query($params,'','&',PHP_QUERY_RFC1738);
     }
 
     public function authorize($options = array())
@@ -103,7 +103,7 @@ abstract class IdentityProvider
         try {
             switch ($this->method) {
                 case 'get':
-                    $client = new GuzzleClient($this->urlAccessToken() . '?' . http_build_query($requestParams));
+                    $client = new GuzzleClient($this->urlAccessToken() . '?' . http_build_query($requestParams,'','&',PHP_QUERY_RFC1738));
                     $request = $client->send();
                     $response = $request->getBody();
                     break;


### PR DESCRIPTION
Changed IdentityProvider to enforce & as query param separator, this will according to php spec ignore ini setting. 
