### PR TITLE
Image URL not present within Google Identity

### DIFF
--- a/src/League/OAuth2/Client/Provider/Google.php
+++ b/src/League/OAuth2/Client/Provider/Google.php
@@ -35,7 +35,7 @@ class Google extends IdentityProvider
         $user->firstName = $response['given_name'];
         $user->lastName = $response['family_name'];
         $user->email = $response['email'];
-        $user->image = (isset($response['picture'])) ? $response['picture'] : null;
+        $user->imageUrl = (isset($response['picture'])) ? $response['picture'] : null;
         return $user;
     }
 


### PR DESCRIPTION
Image url is set to incorrect key within the User Object.
