### PR TITLE
Set required PHP version to 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/php-loep/oauth2-client",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "guzzle/guzzle": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Update required PHP version to 5.4 because the fourth parameter in http_build_query is not available in previous PHP versions.
