### PR TITLE
Utility method to create Guzzle Client, PSR-2 compliance for Grants

### DIFF
--- a/src/League/OAuth2/Client/Grant/AuthorizationCode.php
+++ b/src/League/OAuth2/Client/Grant/AuthorizationCode.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace League\OAuth2\Client\Grant;
+
+use League\OAuth2\Client\Token\AccessToken as AccessToken;
+
+class AuthorizationCode implements GrantInterface
+{
+    public function __toString()
+    {
+        return 'authorization_code';
+    }
+
+    public function prepRequestParams($defaultParams, $params)
+    {
+        if ( ! isset($params['code']) || empty($params['code'])) {
+            throw new \BadMethodCallException('Missing authorization code');
+        }
+
+        return array_merge($defaultParams, $params);
+    }
+
+    public function handleResponse($response = array())
+    {
+        return new AccessToken($response);
+    }
+}

--- a/src/League/OAuth2/Client/Grant/ClientCredentials.php
+++ b/src/League/OAuth2/Client/Grant/ClientCredentials.php
@@ -4,19 +4,15 @@ namespace League\OAuth2\Client\Grant;
 
 use League\OAuth2\Client\Token\AccessToken as AccessToken;
 
-class Authorizationcode implements GrantInterface
-{
+class ClientCredentials implements GrantInterface {
+
     public function __toString()
     {
-        return 'authorization_code';
+        return 'client_credentials';
     }
 
     public function prepRequestParams($defaultParams, $params)
     {
-        if ( ! isset($params['code']) || empty($params['code'])) {
-            throw new \BadMethodCallException('Missing authorization code');
-        }
-
         return array_merge($defaultParams, $params);
     }
 

--- a/src/League/OAuth2/Client/Provider/IdentityProvider.php
+++ b/src/League/OAuth2/Client/Provider/IdentityProvider.php
@@ -81,10 +81,15 @@ abstract class IdentityProvider
         exit;
     }
 
+    protected function getClient($url)
+    {
+        return new GuzzleClient($url);
+    }
+
     public function getAccessToken($grant = 'authorization_code', $params = array())
     {
         if (is_string($grant)) {
-            $grant = 'League\\OAuth2\\Client\\Grant\\'.ucfirst(str_replace('_', '', $grant));
+            $grant = 'League\\OAuth2\\Client\\Grant\\' . implode("", array_map("ucfirst", explode("_", $grant)));
             if ( ! class_exists($grant)) {
                 throw new \InvalidArgumentException('Unknown grant "'.$grant.'"');
             }
@@ -105,12 +110,12 @@ abstract class IdentityProvider
         try {
             switch ($this->method) {
                 case 'get':
-                    $client = new GuzzleClient($this->urlAccessToken() . '?' . http_build_query($requestParams,'','&',PHP_QUERY_RFC1738));
+                    $client = $this->getClient($this->urlAccessToken() . '?' . http_build_query($requestParams,'','&',PHP_QUERY_RFC1738));
                     $request = $client->send();
                     $response = $request->getBody();
                     break;
                 case 'post':
-                    $client = new GuzzleClient($this->urlAccessToken());
+                    $client = $this->getClient($this->urlAccessToken());
                     $request = $client->post(null, null, $requestParams)->send();
                     $response = $request->getBody();
                     break;
@@ -172,7 +177,7 @@ abstract class IdentityProvider
 
             try {
 
-                $client = new GuzzleClient($url);
+                $client = $this->getClient($url);
 
                 if ($this->headers) {
                     $client->setDefaultOption('headers', $this->headers);


### PR DESCRIPTION
- I added PSR-2 compliance for grant names (AuthorizationCode vs. Authorizationcode).
- Implemented the client_credentials grant (self explanatory).
- I created a "getClient" utility method in IdentityProvider: This allows us to override the default Guzzle Client object adding additional headers or other options, or mocking the client requests (useful for unit tests). Specifically, I needed to modify the behavior for testing an OAuth2 client against a self-signed SSL endpoint:

``` php
protected function getClient($url)
{
        $client = new GuzzleClient($url);
        $client->setDefaultOption('verify', false);
        return $client;
}
```
