### PR TITLE
Fix issue if Facebook user doesn't have a username

### DIFF
--- a/src/League/OAuth2/Client/Provider/Facebook.php
+++ b/src/League/OAuth2/Client/Provider/Facebook.php
@@ -28,7 +28,7 @@ class Facebook extends IdentityProvider
 
         $user = new User;
         $user->uid = $response->id;
-        $user->nickname = $response->username;
+        $user->nickname = isset($response->username) ? $response->username : null;
         $user->name = $response->name;
         $user->firstName = $response->first_name;
         $user->lastName = $response->last_name;


### PR DESCRIPTION
See #67, but I've been seeing this issue in our own logs too. A good proportion of Facebook users still do not have usernames. This prevents an error from occurring when they do not.
