### PR TITLE
Fix non-standard uid and expires.  And this library was creating a times...

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -24,6 +24,7 @@ class User
                 $name
             ));
         }
+
         return $this->{$name};
     }
 
@@ -69,6 +70,8 @@ class User
             $key = strtolower($key);
             switch ($key) {
                 case 'uid':
+                case 'user_id':
+                case 'x_mailru_vid':
                     $this->uid = $value;
                     break;
                 case 'nickname':

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -94,6 +94,12 @@ abstract class AbstractProvider
             'approval_prompt' => 'auto'
         );
 
+        if ($this->requireState and !isset($options['state'])) {
+            throw new \Exception('state is a required parameter for this Provider');
+        } elseif ($this->requireState) {
+            $params['state'] = $options['state'];
+        }
+
         return $this->urlAuthorize() . '?' . $this->httpBuildQuery($params, '', '&');
     }
 

--- a/src/Provider/Vkontakte.php
+++ b/src/Provider/Vkontakte.php
@@ -61,7 +61,7 @@ class Vkontakte extends AbstractProvider
         $description = (isset($response->status)) ? $response->status : null;
 
         $user->exchangeArray(array(
-            'uid' => $response->uid,
+            'uid' => $response->user_id,
             'nickname' => $response->nickname,
             'name' => $response->screen_name,
             'firstname' => $response->first_name,
@@ -77,22 +77,18 @@ class Vkontakte extends AbstractProvider
 
     public function userUid($response, \League\OAuth2\Client\Token\AccessToken $token)
     {
-        $response = $response->response[0];
-
-        return $response->uid;
+        return $this->userDetails($response, $token)->uid;
     }
 
     public function userEmail($response, \League\OAuth2\Client\Token\AccessToken $token)
     {
-        $response = $response->response[0];
-
-        return isset($response->email) && $response->email ? $response->email : null;
+        return $this->userDetails($response, $token)->email;
     }
 
     public function userScreenName($response, \League\OAuth2\Client\Token\AccessToken $token)
     {
-        $response = $response->response[0];
+        $user = $this->userDetails($response, $token);
 
-        return array($response->first_name, $response->last_name);
+        return array($user->firstName, $user->lastName);
     }
 }

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -14,7 +14,7 @@ class AccessToken
     /**
      * @var  int  expires
      */
-    public $expires;
+    public $expires_in;
 
     /**
      * @var  string  refreshToken
@@ -41,23 +41,30 @@ class AccessToken
 
         $this->accessToken = $options['access_token'];
 
-        // Some providers (not many) give the uid here, so lets take it
-        isset($options['uid']) and $this->uid = $options['uid'];
+        // Find uid
+        if (isset($options['uid'])) {
+            $this->uid = $options['uid'];
+        } elseif (isset($options['user_id'])) {
+            // Vkontakte uses user_id instead of uid
+            $this->uid = $options['user_id'];
+        } elseif (isset($options['x_mailru_vid'])) {
+            // Mailru uses x_mailru_vid instead of uid
+            $this->uid = $options['x_mailru_vid'];
+        }
 
-        // Vkontakte uses user_id instead of uid
-        isset($options['user_id']) and $this->uid = $options['user_id'];
-
-        // Mailru uses x_mailru_vid instead of uid
-        isset($options['x_mailru_vid']) and $this->uid = $options['x_mailru_vid'];
-
-        // We need to know when the token expires, add num. seconds to current time
-        isset($options['expires_in']) and $this->expires = time() + ((int) $options['expires_in']);
-
-        // Facebook is just being a spec ignoring jerk
-        isset($options['expires']) and $this->expires = time() + ((int) $options['expires']);
+        // The OAuth2 spec works in expires_in values and
+        // not expiratory dates (as previously coded)
+        if (isset($options['expires_in'])) {
+            $this->expires_in = $options['expires_in'];
+        } elseif (isset($options['expires'])) {
+            // Facebook uses expires instead of expires_in
+            $this->expires_in = $options['expires'];
+        }
 
         // Grab a refresh token so we can update access tokens when they expires
-        isset($options['refresh_token']) and $this->refreshToken = $options['refresh_token'];
+        if (isset($options['refresh_token'])) {
+            $this->refreshToken = $options['refresh_token'];
+        }
     }
 
     /**

--- a/test/src/Entity/UserTest.php
+++ b/test/src/Entity/UserTest.php
@@ -29,24 +29,24 @@ class UserTest extends \PHPUnit_Framework_TestCase
 
     public function testExchangeArrayGetArrayCopy()
     {
-	$this->user->exchangeArray($this->userArray);
+    $this->user->exchangeArray($this->userArray);
         $this->assertEquals($this->userArray, $this->user->getArrayCopy());
     }
 
     public function testMagicMethos()
     {
-	$this->user->exchangeArray($this->userArray);
+    $this->user->exchangeArray($this->userArray);
 
         $this->user->name = 'mock_change_test';
 
-	$this->assertTrue(isset($this->user->name));
+    $this->assertTrue(isset($this->user->name));
         $this->assertEquals('mock_change_test', $this->user->name);
     }
 
     /**
      * @expectedException PHPUnit_Framework_Error_Notice
      * Acutal exception expected below but magic testing on phpunit give above
-     * @expectedException \OutOfRangeException 
+     * @expectedException \OutOfRangeException
      */
     public function testInvalidMagicSet()
     {
@@ -54,7 +54,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \OutOfRangeException 
+     * @expectedException \OutOfRangeException
      */
     public function testInvalidMagicGet()
     {

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -4,7 +4,7 @@ namespace LeagueTest\OAuth2\Client\Provider;
 
 use \Mockery as m;
 
-class IdentityProviderTest extends \PHPUnit_Framework_TestCase
+class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 {
     protected $provider;
 

--- a/test/src/Provider/EventbriteTest.php
+++ b/test/src/Provider/EventbriteTest.php
@@ -47,7 +47,7 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
     public function testGetAccessToken()
     {
         $response = m::mock('Guzzle\Http\Message\Response');
-        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(1);
@@ -59,8 +59,7 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
 #    print_r($token);die();
 
         $this->assertEquals('mock_access_token', $token->accessToken);
-        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
-        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals(3600, $token->expires_in);
         $this->assertEquals('mock_refresh_token', $token->refreshToken);
         $this->assertEquals('1', $token->uid);
     }
@@ -73,7 +72,7 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         $postResponse = m::mock('Guzzle\Http\Message\Response');
-        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
         $getResponse->shouldReceive('getBody')->times(1)->andReturn('{"user": {"user_id": 12345, "email": "mock_email"}}');

--- a/test/src/Provider/FacebookTest.php
+++ b/test/src/Provider/FacebookTest.php
@@ -59,8 +59,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
 #    print_r($token);die();
 
         $this->assertEquals('mock_access_token', $token->accessToken);
-        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
-        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals(3600, $token->expires_in);
         $this->assertEquals('mock_refresh_token', $token->refreshToken);
         $this->assertEquals('1', $token->uid);
     }

--- a/test/src/Provider/GithubTest.php
+++ b/test/src/Provider/GithubTest.php
@@ -47,7 +47,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
     public function testGetAccessToken()
     {
         $response = m::mock('Guzzle\Http\Message\Response');
-        $response->shouldReceive('getBody')->times(1)->andReturn('access_token=mock_access_token&expires=3600&refresh_token=mock_refresh_token&uid=1');
+        $response->shouldReceive('getBody')->times(1)->andReturn('access_token=mock_access_token&expires_in=3600&refresh_token=mock_refresh_token&uid=1');
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(1);
@@ -57,8 +57,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals('mock_access_token', $token->accessToken);
-        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
-        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals(3600, $token->expires_in);
         $this->assertEquals('mock_refresh_token', $token->refreshToken);
         $this->assertEquals('1', $token->uid);
     }
@@ -72,7 +71,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         $postResponse = m::mock('Guzzle\Http\Message\Response');
-        $postResponse->shouldReceive('getBody')->times(1)->andReturn('access_token=mock_access_token&expires=3600&refresh_token=mock_refresh_token&uid=1');
+        $postResponse->shouldReceive('getBody')->times(1)->andReturn('access_token=mock_access_token&expires_in=3600&refresh_token=mock_refresh_token&uid=1');
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
         $getResponse->shouldReceive('getBody')->times(1)->andReturn('{"id": 12345, "login": "mock_login", "name": "mock_name", "email": "mock_email"}');

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -47,7 +47,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
     public function testGetAccessToken()
     {
         $response = m::mock('Guzzle\Http\Message\Response');
-        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(1);
@@ -59,8 +59,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
 #    print_r($token);die();
 
         $this->assertEquals('mock_access_token', $token->accessToken);
-        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
-        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals(3600, $token->expires_in);
         $this->assertEquals('mock_refresh_token', $token->refreshToken);
         $this->assertEquals('1', $token->uid);
     }
@@ -73,7 +72,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         $postResponse = m::mock('Guzzle\Http\Message\Response');
-        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
         $getResponse->shouldReceive('getBody')->times(1)->andReturn('{"id": 12345, "name": "mock_name", "given_name": "mock_first_name", "family_name": "mock_last_name", "email": "mock_email"}');

--- a/test/src/Provider/InstagramTest.php
+++ b/test/src/Provider/InstagramTest.php
@@ -47,7 +47,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
     public function testGetAccessToken()
     {
         $response = m::mock('Guzzle\Http\Message\Response');
-        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(1);
@@ -59,8 +59,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
 #    print_r($token);die();
 
         $this->assertEquals('mock_access_token', $token->accessToken);
-        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
-        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals(3600, $token->expires_in);
         $this->assertEquals('mock_refresh_token', $token->refreshToken);
         $this->assertEquals('1', $token->uid);
     }
@@ -73,7 +72,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         $postResponse = m::mock('Guzzle\Http\Message\Response');
-        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
         $getResponse->shouldReceive('getBody')->times(1)->andReturn('{"data": {"id": "12345", "username": "mock_username", "full_name": "mock_full_name", "bio": "mock_bio", "profile_picture": "mock_profile_picture"}}');

--- a/test/src/Provider/LinkedInTest.php
+++ b/test/src/Provider/LinkedInTest.php
@@ -47,7 +47,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
     public function testGetAccessToken()
     {
         $response = m::mock('Guzzle\Http\Message\Response');
-        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(1);
@@ -59,8 +59,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
 #    print_r($token);die();
 
         $this->assertEquals('mock_access_token', $token->accessToken);
-        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
-        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals(3600, $token->expires_in);
         $this->assertEquals('mock_refresh_token', $token->refreshToken);
         $this->assertEquals('1', $token->uid);
     }
@@ -73,7 +72,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         $postResponse = m::mock('Guzzle\Http\Message\Response');
-        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
         $getResponse->shouldReceive('getBody')->times(1)->andReturn('{"id": 12345, "firstName": "mock_first_name", "lastName": "mock_last_name", "emailAddress": "mock_email", "location": { "name": "mock_location" }, "headline": "mock_headline", "pictureUrl": "mock_picture_url", "publicProfileUrl": "mock_profile_url"}');

--- a/test/src/Provider/MicrosoftTest.php
+++ b/test/src/Provider/MicrosoftTest.php
@@ -47,7 +47,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
     public function testGetAccessToken()
     {
         $response = m::mock('Guzzle\Http\Message\Response');
-        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(1);
@@ -59,8 +59,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
 #    print_r($token);die();
 
         $this->assertEquals('mock_access_token', $token->accessToken);
-        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
-        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals(3600, $token->expires_in);
         $this->assertEquals('mock_refresh_token', $token->refreshToken);
         $this->assertEquals('1', $token->uid);
     }
@@ -73,7 +72,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         $postResponse = m::mock('Guzzle\Http\Message\Response');
-        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
         $getResponse->shouldReceive('getBody')->times(1)->andReturn('{"id": 12345, "name": "mock_name", "first_name": "mock_first_name", "last_name": "mock_last_name", "emails": {"preferred": "mock_email"}, "link": "mock_link"}');

--- a/test/src/Provider/VkontakteTest.php
+++ b/test/src/Provider/VkontakteTest.php
@@ -47,7 +47,7 @@ class VkontakteTest extends \PHPUnit_Framework_TestCase
     public function testGetAccessToken()
     {
         $response = m::mock('Guzzle\Http\Message\Response');
-        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "user_id": 1}');
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(1);
@@ -57,8 +57,7 @@ class VkontakteTest extends \PHPUnit_Framework_TestCase
         $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals('mock_access_token', $token->accessToken);
-        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
-        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals(3600, $token->expires_in);
         $this->assertEquals('mock_refresh_token', $token->refreshToken);
         $this->assertEquals('1', $token->uid);
     }
@@ -71,10 +70,10 @@ class VkontakteTest extends \PHPUnit_Framework_TestCase
     public function testUserData()
     {
         $postResponse = m::mock('Guzzle\Http\Message\Response');
-        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires_in": 3600, "refresh_token": "mock_refresh_token", "user_id": 1}');
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
-        $getResponse->shouldReceive('getBody')->times(1)->andReturn('{"response": [{"uid": 12345, "nickname": "mock_nickname", "screen_name": "mock_name", "first_name": "mock_first_name", "last_name": "mock_last_name", "email": "mock_email", "country": "UK", "status": "mock_status", "photo_200_orig": "mock_image_url"}]}');
+        $getResponse->shouldReceive('getBody')->times(1)->andReturn('{"response": [{"user_id": 12345, "nickname": "mock_nickname", "screen_name": "mock_name", "first_name": "mock_first_name", "last_name": "mock_last_name", "email": "mock_email", "country": "UK", "status": "mock_status", "photo_200_orig": "mock_image_url"}]}');
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(1);


### PR DESCRIPTION
...tamp for expires where the spec clearly states (seconds)expires_in should be used and this has been corrected.

Conflicts:
    src/Provider/AbstractProvider.php
