### PR TITLE
Expose generated state to allow for CSRF validation.

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -16,6 +16,8 @@ abstract class AbstractProvider
 
     public $redirectUri = '';
 
+    public $state;
+
     public $name;
 
     public $uidKey = 'uid';
@@ -83,12 +85,12 @@ abstract class AbstractProvider
 
     public function getAuthorizationUrl($options = array())
     {
-        $state = md5(uniqid(rand(), true));
+        $this->state = md5(uniqid(rand(), true));
 
         $params = array(
             'client_id' => $this->clientId,
             'redirect_uri' => $this->redirectUri,
-            'state' => $state,
+            'state' => $this->state,
             'scope' => is_array($this->scopes) ? implode($this->scopeSeparator, $this->scopes) : $this->scopes,
             'response_type' => isset($options['response_type']) ? $options['response_type'] : 'code',
             'approval_prompt' => 'auto'

--- a/test/src/Provider/EventbriteTest.php
+++ b/test/src/Provider/EventbriteTest.php
@@ -29,6 +29,7 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
     }
 
     public function testUrlAccessToken()

--- a/test/src/Provider/FacebookTest.php
+++ b/test/src/Provider/FacebookTest.php
@@ -29,6 +29,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
     }
 
     public function testUrlAccessToken()

--- a/test/src/Provider/GithubTest.php
+++ b/test/src/Provider/GithubTest.php
@@ -29,6 +29,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
     }
 
     public function testUrlAccessToken()

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -29,6 +29,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
     }
 
     public function testUrlAccessToken()

--- a/test/src/Provider/InstagramTest.php
+++ b/test/src/Provider/InstagramTest.php
@@ -29,6 +29,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
     }
 
     public function testUrlAccessToken()

--- a/test/src/Provider/LinkedInTest.php
+++ b/test/src/Provider/LinkedInTest.php
@@ -29,6 +29,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
     }
 
     public function testUrlAccessToken()

--- a/test/src/Provider/MicrosoftTest.php
+++ b/test/src/Provider/MicrosoftTest.php
@@ -29,6 +29,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
     }
 
     public function testUrlAccessToken()

--- a/test/src/Provider/VkontakteTest.php
+++ b/test/src/Provider/VkontakteTest.php
@@ -29,6 +29,7 @@ class VkontakteTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('scope', $query);
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
     }
 
     public function testUrlAccessToken()


### PR DESCRIPTION
Exposing the generated state gives developers the ability to store and validate for CSRF protection.
