### PR TITLE
User gender and locale

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -14,6 +14,8 @@ class User
     protected $description;
     protected $imageUrl;
     protected $urls;
+    protected $gender;
+    protected $locale;
 
     public function __get($name)
     {
@@ -61,6 +63,8 @@ class User
             'description' => $this->description,
             'imageUrl' => $this->imageUrl,
             'urls' => $this->urls,
+            'gender' => $this->gender,
+            'locale' => $this->locale,
         );
     }
 
@@ -98,6 +102,12 @@ class User
                     break;
                 case 'urls':
                     $this->urls = $value;
+                    break;
+                case 'gender':
+                    $this->gender = $value;
+                    break;
+                case 'locale':
+                    $this->locale = $value;
                     break;
             }
         }

--- a/test/src/Entity/UserTest.php
+++ b/test/src/Entity/UserTest.php
@@ -24,7 +24,9 @@ class UserTest extends \PHPUnit_Framework_TestCase
             'location' => 'mock_location',
             'description' => 'mock_description',
             'imageUrl' => 'mock_imageUrl',
-            'urls' => 'mock_urls'
+            'urls' => 'mock_urls',
+            'gender' => 'mock_gender',
+            'locale' => 'mock_locale'
         );
     }
 


### PR DESCRIPTION
Could we extend `User` entity with new properties so that it would enable getting `gender` and `locale`? I'm not sure if it's intended to provide only the bare minimum for all providers, or if this situation is meant to be handled some other way? 

I'll submit a PR soon.
