### PR TITLE
add an interface for injection typehints

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -8,7 +8,7 @@ use League\OAuth2\Client\Token\AccessToken as AccessToken;
 use League\OAuth2\Client\Exception\IDPException as IDPException;
 use League\OAuth2\Client\Grant\GrantInterface;
 
-abstract class AbstractProvider
+abstract class AbstractProvider implements ProviderInterface
 {
     public $clientId = '';
 

--- a/src/Provider/ProviderInterface.php
+++ b/src/Provider/ProviderInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace League\OAuth2\Client\Provider;
+
+use League\OAuth2\Client\Token\AccessToken as AccessToken;
+
+interface ProviderInterface
+{
+    public function urlAuthorize();
+
+    public function urlAccessToken();
+
+    public function urlUserDetails(AccessToken $token);
+
+    public function userDetails($response, AccessToken $token);
+
+    public function getScopes();
+
+    public function setScopes(array $scopes);
+
+    public function getAuthorizationUrl($options = array());
+
+    public function authorize($options = array());
+
+    public function getAccessToken($grant = 'authorization_code', $params = array());
+
+    public function getUserDetails(AccessToken $token);
+
+    public function getUserUid(AccessToken $token);
+
+    public function getUserEmail(AccessToken $token);
+
+    public function getUserScreenName(AccessToken $token);
+}


### PR DESCRIPTION
This allows classes using a _Provider_ to typehint against _ProviderInterface_ instead of _AbstractProvider_. There are no behavioral changes. All tests pass.
