### PR TITLE
Updated test to replace old /token path test

### DIFF
--- a/test/src/Provider/MicrosoftTest.php
+++ b/test/src/Provider/MicrosoftTest.php
@@ -37,7 +37,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
         $url = $this->provider->urlAccessToken();
         $uri = parse_url($url);
 
-        $this->assertEquals('/token', $uri['path']);
+        $this->assertEquals('/oauth20_token.srf', $uri['path']);
     }
 
     public function testGetAccessToken()


### PR DESCRIPTION
Changed /token to /oauth20_token.srf to conform to new url
