### PR TITLE
Added `scopes` in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ The following versions of PHP are supported.
 $provider = new League\OAuth2\Client\Provider\<ProviderName>(array(
     'clientId'  =>  'XXXXXXXX',
     'clientSecret'  =>  'XXXXXXXX',
-    'redirectUri'   =>  'https://your-registered-redirect-uri/'
+    'redirectUri'   =>  'https://your-registered-redirect-uri/',
+    'scopes' => array('email', '...', '...'),
 ));
 
 if ( ! isset($_GET['code'])) {


### PR DESCRIPTION
There is no documentation about how to set scopes, it's not explicit at all. Hopefully this updated example will help to understand.
