### PR TITLE
Adds .gitattributes that excludes paths when installed via --prefer-dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/test               export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.travis.yml        export-ignore
+/phpunit.xml        export-ignore


### PR DESCRIPTION
Adds `.gitattributes` in response to recommendations below.

See https://groups.google.com/forum/#!topic/thephpleague/jyPyZJPwImc
See https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production/
