### PR TITLE
Draft implementation of properly setting UIDs in a provider specific fashion

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,35 @@ so please help them out with a pull request if you notice this.
 - [Weibo](https://github.com/tlikai/oauth2-client)
 - [Meetup](https://github.com/howlowck/meetup-oauth2-provider)
 
+### Implementing your own provider
+
+If you are working with an oauth2 service not supported out-of-the-box or by an existing package, it is quite simple to
+implement your own. Simply extend `League\OAuth2\Client\Provider\AbstractProvider` and implement the required abstract
+methods:
+
+```php
+abstract public function urlAuthorize();
+abstract public function urlAccessToken();
+abstract public function urlUserDetails(\League\OAuth2\Client\Token\AccessToken $token);
+abstract public function userDetails($response, \League\OAuth2\Client\Token\AccessToken $token);
+```
+
+Each of these abstract methods contain a docblock defining their expectations and typical behaviour. Once you have
+extended this class, you can simply follow the example above using your new `Provider`.
+
+#### Custom account identifiers in access token responses
+
+Some OAuth2 Server implementations include a field in their access token response defining some identifier
+for the user account that just requested the access token. In many cases this field, if present, is called "uid", but
+some providers define custom identifiers in their response. If your provider uses a nonstandard name for the "uid" field,
+when extending the AbstractProvider, in your new class, define a property `public $uidKey` and set it equal to whatever
+your provider uses as its key. For example, Battle.net uses `accountId` as the key for the identifier field, so in that
+provider you would add a property:
+
+```php
+public $uidKey = 'accountId';
+```
+
 ### Client Packages
 
 Some developers use this library as a base for their own PHP API wrappers, and that seems like a really great idea. It might make it slightly tricky to integrate their provider with an existing generic "OAuth 2.0 All the Things" login system, but it does make working with them easier.

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -65,12 +65,41 @@ abstract class AbstractProvider implements ProviderInterface
         return $client;
     }
 
+    /**
+     * Get the URL that this provider uses to begin authorization.
+     *
+     * @return string
+     */
     abstract public function urlAuthorize();
 
+    /**
+     * Get the URL that this provider users to request an access token.
+     *
+     * @return string
+     */
     abstract public function urlAccessToken();
 
+    /**
+     * Get the URL that this provider uses to request user details.
+     *
+     * Since this URL is typically an authorized route, most providers will require you to pass the access_token as
+     * a parameter to the request. For example, the google url is:
+     *
+     * 'https://www.googleapis.com/oauth2/v1/userinfo?alt=json&access_token='.$token
+     *
+     * @param AccessToken $token
+     * @return string
+     */
     abstract public function urlUserDetails(\League\OAuth2\Client\Token\AccessToken $token);
 
+    /**
+     * Given an object response from the server, process the user details into a format expected by the user
+     * of the client.
+     *
+     * @param object $response
+     * @param AccessToken $token
+     * @return mixed
+     */
     abstract public function userDetails($response, \League\OAuth2\Client\Token\AccessToken $token);
 
     public function getScopes()


### PR DESCRIPTION
To solve the problem referenced in #165, I've added a protected method to AbstractProvider.

Since our providers already have a $uidKey property that is settable by any inheriting provider, this is a really easy way to abstract the maintenance load of knowing exactly what uidkey each provider users to the maintainer of that specific provider.
