### PR TITLE
User id being set for Google API

### DIFF
--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -43,7 +43,7 @@ class Google extends AbstractProvider
     {
         return
             'https://www.googleapis.com/plus/v1/people/me?'.
-            'fields=name(familyName%2CgivenName)%2CdisplayName%2C'.
+            'fields=id%2Cname(familyName%2CgivenName)%2CdisplayName%2C'.
             'emails%2Fvalue%2Cimage%2Furl&alt=json&access_token='.$token;
     }
 


### PR DESCRIPTION
This fixes an issue with #187 where the user id was not being set because the request for the user details did not specifically ask for it.