### PR TITLE
Add support for specifying the access_type parameter for Google OAuth

### DIFF
--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -29,6 +29,10 @@ class Google extends AbstractProvider
         return $this->hostedDomain;
     }
 
+    /**
+     * @var string If set, this will be sent to google as the "access_type" parameter.
+     * @link https://developers.google.com/accounts/docs/OAuth2WebServer#offline
+     */
     public $accessType = '';
 
     public function setAccessType($accessType)

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -29,6 +29,18 @@ class Google extends AbstractProvider
         return $this->hostedDomain;
     }
 
+    public $accessType = '';
+
+    public function setAccessType($accessType)
+    {
+        $this->accessType = $accessType;
+    }
+
+    public function getAccessType()
+    {
+        return $this->accessType;
+    }
+
     public function urlAuthorize()
     {
         return 'https://accounts.google.com/o/oauth2/auth';
@@ -95,6 +107,10 @@ class Google extends AbstractProvider
 
         if (!empty($this->hostedDomain)) {
             $url .= '&' . $this->httpBuildQuery(['hd' => $this->hostedDomain]);
+        }
+
+        if (!empty($this->accessType)) {
+            $url .= '&' . $this->httpBuildQuery(['access_type'=> $this->accessType]);
         }
 
         return $url;

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -15,6 +15,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
             'hostedDomain' => 'mock_domain',
+            'accessType' => 'mock_access_type'
         ]);
     }
 
@@ -37,6 +38,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('response_type', $query);
         $this->assertArrayHasKey('approval_prompt', $query);
         $this->assertArrayHasKey('hd', $query);
+        $this->assertArrayHasKey('access_type', $query);
         $this->assertNotNull($this->provider->state);
     }
 
@@ -106,5 +108,16 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
     {
         $this->provider->setHostedDomain('changed_domain');
         $this->assertEquals('changed_domain', $this->provider->hostedDomain);
+    }
+
+    public function testGetAccessType()
+    {
+        $this->assertEquals('mock_access_type', $this->provider->getAccessType());
+    }
+
+    public function testSetAccessType()
+    {
+        $this->provider->setAccessType('changed_access_type');
+        $this->assertEquals('changed_access_type', $this->provider->accessType);
     }
 }


### PR DESCRIPTION
In order to receive a `refreshToken` from Google Auth, `access_type` must be set to `offline` in the authorization url. The Google provider didn't allow setting this parameter.