### PR TITLE
Remove outdated eventbrite snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ if (!isset($_GET['code'])) {
     	'code' => $_GET['code']
     ]);
 
-    // If you are using Eventbrite you will need to add the grant_type parameter (see below)
-    $token = $provider->getAccessToken('authorization_code', [
-    	'code' => $_GET['code'],
-    	'grant_type' => 'authorization_code'
-    ]);
-
     // Optional: Now you have a token you can look up a users profile data
     try {
 


### PR DESCRIPTION
Eventbrite provider does not need for additional grant_type param anymore. It returns exactly the same data with or without it.
So to clean up usage example and avoid [such](https://github.com/thephpleague/oauth2-client/issues/191) [issues](https://github.com/thephpleague/oauth2-client/issues/183) it's better to drop this outdated snippet.