### PR TITLE
Upgrade Facebook provider to Graph v2.2

### DIFF
--- a/test/src/Provider/FacebookTest.php
+++ b/test/src/Provider/FacebookTest.php
@@ -6,6 +6,9 @@ use Mockery as m;
 
 class FacebookTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \League\OAuth2\Client\Provider\Facebook
+     */
     protected $provider;
 
     protected function setUp()
@@ -42,8 +45,40 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     {
         $url = $this->provider->urlAccessToken();
         $uri = parse_url($url);
+        $graphVersion = \League\OAuth2\Client\Provider\Facebook::DEFAULT_GRAPH_VERSION;
 
-        $this->assertEquals('/oauth/access_token', $uri['path']);
+        $this->assertEquals('/'.$graphVersion.'/oauth/access_token', $uri['path']);
+    }
+
+    public function testGraphApiVersionCanBeCustomized()
+    {
+        $graphVersion = 'v13.37';
+        $provider = new \League\OAuth2\Client\Provider\Facebook([
+            'graphApiVersion' => $graphVersion,
+        ]);
+        $fooToken = new \League\OAuth2\Client\Token\AccessToken(['access_token' => 'foo_token']);
+
+        $urlAuthorize = $provider->urlAuthorize();
+        $urlAccessToken = $provider->urlAccessToken();
+        $urlUserDetails = parse_url($provider->urlUserDetails($fooToken), PHP_URL_PATH);
+
+        $this->assertEquals('https://www.facebook.com/'.$graphVersion.'/dialog/oauth', $urlAuthorize);
+        $this->assertEquals('https://graph.facebook.com/'.$graphVersion.'/oauth/access_token', $urlAccessToken);
+        $this->assertEquals('/'.$graphVersion.'/me', $urlUserDetails);
+    }
+
+    public function testGraphApiVersionWillFallbackToDefault()
+    {
+        $graphVersion = \League\OAuth2\Client\Provider\Facebook::DEFAULT_GRAPH_VERSION;
+        $fooToken = new \League\OAuth2\Client\Token\AccessToken(['access_token' => 'foo_token']);
+
+        $urlAuthorize = $this->provider->urlAuthorize();
+        $urlAccessToken = $this->provider->urlAccessToken();
+        $urlUserDetails = parse_url($this->provider->urlUserDetails($fooToken), PHP_URL_PATH);
+
+        $this->assertEquals('https://www.facebook.com/'.$graphVersion.'/dialog/oauth', $urlAuthorize);
+        $this->assertEquals('https://graph.facebook.com/'.$graphVersion.'/oauth/access_token', $urlAccessToken);
+        $this->assertEquals('/'.$graphVersion.'/me', $urlUserDetails);
     }
 
     public function testGetAccessToken()
@@ -58,8 +93,6 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
 
-#    print_r($token);die();
-
         $this->assertEquals('mock_access_token', $token->accessToken);
         $this->assertLessThanOrEqual(time() + 3600, $token->expires);
         $this->assertGreaterThanOrEqual(time(), $token->expires);
@@ -69,7 +102,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals(['offline_access', 'email', 'read_stream'], $this->provider->getScopes());
+        $this->assertEquals(['public_profile', 'email'], $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -82,7 +115,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $getResponse->shouldReceive('getInfo')->andReturn(['url' => 'mock_image_url']);
 
         $client = m::mock('Guzzle\Service\Client');
-        $client->shouldReceive('setBaseUrl')->times(6);
+        $client->shouldReceive('setBaseUrl')->times(5);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->andReturn($getResponse);
         $this->provider->setHttpClient($client);


### PR DESCRIPTION
Hey guys! Did some upgrades to the `Facebook` provider.

# Summary

- Added a `graphApiVersion` option to the `Facebook` provider to specify which version of the Graph API to use. (Addresses #202)
- Added a fallback Graph API version and set it to the [latest version `v2.2`](https://developers.facebook.com/docs/apps/versions).
- Updated the `scopes`:
	- Removed `offline_access` since [that has been removed](https://developers.facebook.com/docs/roadmap/completed-changes/offline-access-removal).
	- Removed the unnecessary [`read_stream` permission](https://developers.facebook.com/docs/facebook-login/permissions/v2.2#reference-read_stream).
	- Added the new [`public_profile` basic permission](https://developers.facebook.com/docs/facebook-login/permissions/v2.2#reference-public_profile).
- Updated the `urlUserDetails()` method:
	- Made use of [nested requests](https://developers.facebook.com/docs/graph-api/using-graph-api/v2.2#fieldexpansion) to grab the user's profile pic and removed the extra request to the `/me/picture` endpoint in the `userDetails()` method.
	- Removed the `username` (`nickname`) field since that field has been deprecated and [is no longer available since `v2.0`](https://developers.facebook.com/docs/apps/changelog#v2_0_graph_api).
	- Added the `gender` & `locale` fields.

# Specifying the Graph version

```php
$this->provider = new \League\OAuth2\Client\Provider\Facebook([
            /* . . . */
            'graphApiVersion' => 'v2.0',
        ]);
```

Let me know if I need to add documentation anywhere for the new `graphApiVersion` option. :)