### PR TITLE
Get reliable body response on error.

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -196,8 +196,7 @@ abstract class AbstractProvider implements ProviderInterface
             }
         } catch (BadResponseException $e) {
             // @codeCoverageIgnoreStart
-            $raw_response = explode("\n", $e->getResponse());
-            $response = end($raw_response);
+            $response = $e->getResponse()->getBody();
             // @codeCoverageIgnoreEnd
         }
 


### PR DESCRIPTION
Certain responses (pretty JSON) cause issues when you try to explode the raw response. This affects the Google provider in my experience. Using the `getBody` method should be more reliable.

Might be related to #193.