### PR TITLE
Add additional method for modifying token response

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -215,9 +215,22 @@ abstract class AbstractProvider implements ProviderInterface
             // @codeCoverageIgnoreEnd
         }
 
-        $this->setResultUid($result);
+        $result = $this->prepareAccessTokenResult($result);
 
         return $grant->handleResponse($result);
+    }
+
+    /**
+     * Prepare the access token response for the grant. Custom mapping of
+     * expirations, etc should be done here.
+     *
+     * @param  array $result
+     * @return array
+     */
+    protected function prepareAccessTokenResult(array $result)
+    {
+        $this->setResultUid($result);
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Create `AbstractProvider::prepareAccessTokenResult` to allow providers to modify token responses. Particularly useful for mapping expirations and capturing any additional details that may come back with the token.