### PR TITLE
Allow provider to add some extra user info to user class

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -32,13 +32,13 @@ class User
 
     public function __set($property, $value)
     {
-        if (!property_exists($this, $property)) {
+        /*if (!property_exists($this, $property)) {
             throw new \OutOfRangeException(sprintf(
                 '%s does not contain a property by the name of "%s"',
                 __CLASS__,
                 $property
             ));
-        }
+        }*/
 
         $this->$property = $value;
 


### PR DESCRIPTION
Some sites not only provides this user info to oauth client,but provider can't add extra info to user class