### PR TITLE
Added getResponseBody method in IDPException

### DIFF
--- a/src/Exception/IDPException.php
+++ b/src/Exception/IDPException.php
@@ -25,6 +25,11 @@ class IDPException extends \Exception
         parent::__construct($message, $code);
     }
 
+    public function getResponseBody()
+    {
+        return $this->result;
+    }
+
     public function getType()
     {
         $result = 'Exception';

--- a/test/src/Exception/IDPExceptionTest.php
+++ b/test/src/Exception/IDPExceptionTest.php
@@ -41,4 +41,17 @@ class IDPExceptionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('message: 404: message', (string)$exception);
     }
+
+    public function testGetResponseBody()
+    {
+        $exception = new IDPException(array('error' => 'message', 'code' => 404));
+
+        $this->assertEquals(
+            [
+                'error' => 'message',
+                'code'  => 404
+            ],
+            $exception->getResponseBody()
+        );
+    }
 }


### PR DESCRIPTION
### Problem:

Some providers are sending additional information when an error occurs, which can't be accessed because property `$result` is protected.

### Solution:

Data from this property can be accessed using `getResponseBody()` method.

Closes #185 and maybe #106 .