### PR TITLE
Enhance ability to use client to make authenticated requests

### DIFF
--- a/src/Provider/Eventbrite.php
+++ b/src/Provider/Eventbrite.php
@@ -6,13 +6,7 @@ use League\OAuth2\Client\Entity\User;
 
 class Eventbrite extends AbstractProvider
 {
-    public function __construct($options)
-    {
-        parent::__construct($options);
-        $this->headers = [
-            'Authorization' => 'Bearer',
-        ];
-    }
+    public $authorizationHeader = 'Bearer';
 
     public function urlAuthorize()
     {
@@ -26,7 +20,7 @@ class Eventbrite extends AbstractProvider
 
     public function urlUserDetails(\League\OAuth2\Client\Token\AccessToken $token)
     {
-        return 'https://www.eventbrite.com/json/user_get?access_token='.$token;
+        return 'https://www.eventbrite.com/json/user_get';
     }
 
     public function userDetails($response, \League\OAuth2\Client\Token\AccessToken $token)

--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -3,10 +3,13 @@
 namespace League\OAuth2\Client\Provider;
 
 use League\OAuth2\Client\Entity\User;
+use League\OAuth2\Client\Token\AccessToken;
 
 class Github extends AbstractProvider
 {
     public $responseType = 'string';
+
+    public $authorizationHeader = 'token';
 
     public $domain = 'https://github.com';
 
@@ -22,23 +25,23 @@ class Github extends AbstractProvider
         return $this->domain.'/login/oauth/access_token';
     }
 
-    public function urlUserDetails(\League\OAuth2\Client\Token\AccessToken $token)
+    public function urlUserDetails(AccessToken $token)
     {
         if ($this->domain === 'https://github.com') {
-            return $this->apiDomain.'/user?access_token='.$token;
+            return $this->apiDomain.'/user';
         }
-        return $this->domain.'/api/v3/user?access_token='.$token;
+        return $this->domain.'/api/v3/user';
     }
 
-    public function urlUserEmails(\League\OAuth2\Client\Token\AccessToken $token)
+    public function urlUserEmails(AccessToken $token)
     {
         if ($this->domain === 'https://github.com') {
-            return $this->apiDomain.'/user/emails?access_token='.$token;
+            return $this->apiDomain.'/user/emails';
         }
-        return $this->domain.'/api/v3/user/emails?access_token='.$token;
+        return $this->domain.'/api/v3/user/emails';
     }
 
-    public function userDetails($response, \League\OAuth2\Client\Token\AccessToken $token)
+    public function userDetails($response, AccessToken $token)
     {
         $user = new User();
 
@@ -58,37 +61,39 @@ class Github extends AbstractProvider
         return $user;
     }
 
-    public function userUid($response, \League\OAuth2\Client\Token\AccessToken $token)
+    public function userUid($response, AccessToken $token)
     {
         return $response->id;
     }
 
-    public function getUserEmails(\League\OAuth2\Client\Token\AccessToken $token)
+    public function getUserEmails(AccessToken $token)
     {
         $response = $this->fetchUserEmails($token);
 
         return $this->userEmails(json_decode($response), $token);
     }
 
-    public function userEmail($response, \League\OAuth2\Client\Token\AccessToken $token)
+    public function userEmail($response, AccessToken $token)
     {
         return isset($response->email) && $response->email ? $response->email : null;
     }
 
-    public function userEmails($response, \League\OAuth2\Client\Token\AccessToken $token)
+    public function userEmails($response, AccessToken $token)
     {
         return $response;
     }
 
-    public function userScreenName($response, \League\OAuth2\Client\Token\AccessToken $token)
+    public function userScreenName($response, AccessToken $token)
     {
         return $response->name;
     }
 
-    protected function fetchUserEmails(\League\OAuth2\Client\Token\AccessToken $token)
+    protected function fetchUserEmails(AccessToken $token)
     {
         $url = $this->urlUserEmails($token);
 
-        return $this->fetchProviderData($url);
+        $headers = $this->getHeaders($token);
+
+        return $this->fetchProviderData($url, $headers);
     }
 }

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -13,6 +13,8 @@ class Google extends AbstractProvider
         'email',
     ];
 
+    public $authorizationHeader = 'OAuth';
+
     /**
      * @var string If set, this will be sent to google as the "hd" parameter.
      * @link https://developers.google.com/accounts/docs/OAuth2Login#hd-param
@@ -60,7 +62,7 @@ class Google extends AbstractProvider
         return
             'https://www.googleapis.com/plus/v1/people/me?'.
             'fields=id%2Cname(familyName%2CgivenName)%2CdisplayName%2C'.
-            'emails%2Fvalue%2Cimage%2Furl&alt=json&access_token='.$token;
+            'emails%2Fvalue%2Cimage%2Furl&alt=json';
     }
 
     public function userDetails($response, \League\OAuth2\Client\Token\AccessToken $token)

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -9,6 +9,7 @@ class LinkedIn extends AbstractProvider
 {
     public $scopes = ['r_basicprofile r_emailaddress r_contactinfo'];
     public $responseType = 'json';
+    public $authorizationHeader = 'Bearer';
     public $fields = [
         'id', 'email-address', 'first-name', 'last-name', 'headline',
         'location', 'industry', 'picture-url', 'public-profile-url',
@@ -26,8 +27,8 @@ class LinkedIn extends AbstractProvider
 
     public function urlUserDetails(AccessToken $token)
     {
-        return 'https://api.linkedin.com/v1/people/~:('.implode(",", $this->fields)
-            .')?format=json&oauth2_access_token='.$token;
+        $fields = implode(',', $this->fields);
+        return 'https://api.linkedin.com/v1/people/~:(' . $fields . ')?format=json';
     }
 
     public function userDetails($response, AccessToken $token)

--- a/src/Provider/ProviderInterface.php
+++ b/src/Provider/ProviderInterface.php
@@ -24,6 +24,8 @@ interface ProviderInterface
 
     public function getAccessToken($grant = 'authorization_code', $params = []);
 
+    public function getHeaders($token = null);
+
     public function getUserDetails(AccessToken $token);
 
     public function getUserUid(AccessToken $token);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -69,6 +69,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'scopeSeparator' => ';',
             'responseType' => 'csv',
             'headers' => ['Foo' => 'Bar'],
+            'authorizationHeader' => 'Bearer',
         ];
 
         $mockProvider = new MockProvider($options);
@@ -141,6 +142,32 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             [$response2],
             [$response3],
         ];
+    }
+
+    public function getHeadersTest()
+    {
+        $provider = $this->getMockForAbstractClass(
+            '\League\OAuth2\Client\Provider\AbstractProvider',
+            [
+              [
+                  'clientId'     => 'mock_client_id',
+                  'clientSecret' => 'mock_secret',
+                  'redirectUri'  => 'none',
+              ]
+            ]
+        );
+
+        /**
+         * @var $provider AbstractProvider
+         */
+        $this->assertEquals([], $provider->getHeaders());
+        $this->assertEquals([], $provider->getHeaders('mock_token'));
+
+        $provider->authorizationHeader = 'Bearer';
+        $this->assertEquals(['Authorization' => 'Bearer abc'], $provider->getHeaders('abc'));
+
+        $token = new AccessToken(['access_token' => 'xyz', 'expires_in' => 3600]);
+        $this->assertEquals(['Authorization' => 'Bearer xyz'], $provider->getHeaders($token));
     }
 }
 

--- a/test/src/Provider/GithubTest.php
+++ b/test/src/Provider/GithubTest.php
@@ -102,6 +102,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(5);
+        $client->shouldReceive('setDefaultOption')->times(4);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
@@ -128,8 +129,8 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->provider->domain.'/login/oauth/authorize', $this->provider->urlAuthorize());
         $this->assertEquals($this->provider->domain.'/login/oauth/access_token', $this->provider->urlAccessToken());
-        $this->assertEquals($this->provider->apiDomain.'/user?access_token=mock_access_token', $this->provider->urlUserDetails($token));
-        $this->assertEquals($this->provider->apiDomain.'/user/emails?access_token=mock_access_token', $this->provider->urlUserEmails($token));
+        $this->assertEquals($this->provider->apiDomain.'/user', $this->provider->urlUserDetails($token));
+        $this->assertEquals($this->provider->apiDomain.'/user/emails', $this->provider->urlUserEmails($token));
     }
 
     public function testGithubEnterpriseDomainUrls()
@@ -147,8 +148,8 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($this->provider->domain.'/login/oauth/authorize', $this->provider->urlAuthorize());
         $this->assertEquals($this->provider->domain.'/login/oauth/access_token', $this->provider->urlAccessToken());
-        $this->assertEquals($this->provider->domain.'/api/v3/user?access_token=mock_access_token', $this->provider->urlUserDetails($token));
-        $this->assertEquals($this->provider->domain.'/api/v3/user/emails?access_token=mock_access_token', $this->provider->urlUserEmails($token));
+        $this->assertEquals($this->provider->domain.'/api/v3/user', $this->provider->urlUserDetails($token));
+        $this->assertEquals($this->provider->domain.'/api/v3/user/emails', $this->provider->urlUserEmails($token));
     }
 
     public function testUserEmails()
@@ -161,6 +162,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(2);
+        $client->shouldReceive('setDefaultOption')->times(1);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(1)->andReturn($getResponse);
         $this->provider->setHttpClient($client);

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -62,8 +62,6 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
 
-#    print_r($token);die();
-
         $this->assertEquals('mock_access_token', $token->accessToken);
         $this->assertLessThanOrEqual(time() + 3600, $token->expires);
         $this->assertGreaterThanOrEqual(time(), $token->expires);
@@ -86,6 +84,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(5);
+        $client->shouldReceive('setDefaultOption')->times(4);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);

--- a/test/src/Provider/LinkedInTest.php
+++ b/test/src/Provider/LinkedInTest.php
@@ -58,8 +58,6 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
 
-#    print_r($token);die();
-
         $this->assertEquals('mock_access_token', $token->accessToken);
         $this->assertLessThanOrEqual(time() + 3600, $token->expires);
         $this->assertGreaterThanOrEqual(time(), $token->expires);
@@ -82,6 +80,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(5);
+        $client->shouldReceive('setDefaultOption')->times(4);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);


### PR DESCRIPTION
- add `ProviderInterface::getHeaders()`
- use `getHeaders()` for `fetchUserDetails()`

Some providers do not provide a method for using query strings to send tokens.
By adding hooks for headers, the provider can be used to sign API requests,
including POST requests.