### PR TITLE
Stop using deprecated Travis option --dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer require satooshi/php-coveralls:dev-master --no-update --dev
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer require satooshi/php-coveralls:dev-master --no-update
+  - travis_retry composer install --no-interaction --prefer-source
 
 script: 
   - mkdir -p build/logs


### PR DESCRIPTION
As per recent Travis builds:

> You are using the deprecated option "dev". Dev packages are installed by default now.