### PR TITLE
PHP5.3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: php
 
 php:
   - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
+  #- 5.4
+  #- 5.5
+  #- 5.6
+  #- hhvm
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: php
 
 php:
   - 5.3
-  #- 5.4
-  #- 5.5
-  #- 5.6
-  #- hhvm
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
 
 before_script:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer require satooshi/php-coveralls:dev-master --no-update --dev
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer require satooshi/php-coveralls:dev-master --no-update
+  - travis_retry composer install --no-interaction --prefer-source
 
 script: 
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "OAuth 2.0 Client Library",
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.3.0",
         "guzzle/guzzle": "~3.7"
     },
     "require-dev": {

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -52,7 +52,7 @@ class User
 
     public function getArrayCopy()
     {
-        return [
+        return array(
             'uid' => $this->uid,
             'nickname' => $this->nickname,
             'name' => $this->name,
@@ -65,7 +65,7 @@ class User
             'urls' => $this->urls,
             'gender' => $this->gender,
             'locale' => $this->locale,
-        ];
+        );
     }
 
     public function exchangeArray(array $data)

--- a/src/Grant/AuthorizationCode.php
+++ b/src/Grant/AuthorizationCode.php
@@ -20,7 +20,7 @@ class AuthorizationCode implements GrantInterface
         return array_merge($defaultParams, $params);
     }
 
-    public function handleResponse($response = [])
+    public function handleResponse($response = array())
     {
         return new AccessToken($response);
     }

--- a/src/Grant/GrantInterface.php
+++ b/src/Grant/GrantInterface.php
@@ -6,7 +6,7 @@ interface GrantInterface
 {
     public function __toString();
 
-    public function handleResponse($response = []);
+    public function handleResponse($response = array());
 
     public function prepRequestParams($defaultParams, $params);
 }

--- a/src/Grant/RefreshToken.php
+++ b/src/Grant/RefreshToken.php
@@ -22,7 +22,7 @@ class RefreshToken implements GrantInterface
         return array_merge($defaultParams, $params);
     }
 
-    public function handleResponse($response = [])
+    public function handleResponse($response = array())
     {
         return new AccessToken($response);
     }

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -152,7 +152,7 @@ abstract class AbstractProvider implements ProviderInterface
     {
         if (is_string($grant)) {
             // PascalCase the grant. E.g: 'authorization_code' becomes 'AuthorizationCode'
-            $className = str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $grant)));
+            $className = str_replace(' ', '', ucwords(str_replace(array('-', '_'), ' ', $grant)));
             $grant = 'League\\OAuth2\\Client\\Grant\\'.$className;
             if (! class_exists($grant)) {
                 throw new \InvalidArgumentException('Unknown grant "'.$grant.'"');

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -23,7 +23,7 @@ abstract class AbstractProvider implements ProviderInterface
 
     public $uidKey = 'uid';
 
-    public $scopes = [];
+    public $scopes = array()
 
     public $method = 'post';
 
@@ -46,7 +46,7 @@ abstract class AbstractProvider implements ProviderInterface
      */
     protected $httpBuildEncType = 1;
 
-    public function __construct($options = [])
+    public function __construct($options = array())
     {
         foreach ($options as $option => $value) {
             if (property_exists($this, $option)) {
@@ -118,24 +118,24 @@ abstract class AbstractProvider implements ProviderInterface
         $this->scopes = $scopes;
     }
 
-    public function getAuthorizationUrl($options = [])
+    public function getAuthorizationUrl($options = array())
     {
         $this->state = isset($options['state']) ? $options['state'] : md5(uniqid(rand(), true));
 
-        $params = [
+        $params = array(
             'client_id' => $this->clientId,
             'redirect_uri' => $this->redirectUri,
             'state' => $this->state,
             'scope' => is_array($this->scopes) ? implode($this->scopeSeparator, $this->scopes) : $this->scopes,
             'response_type' => isset($options['response_type']) ? $options['response_type'] : 'code',
             'approval_prompt' => isset($options['approval_prompt']) ? $options['approval_prompt'] : 'auto',
-        ];
+        );
 
         return $this->urlAuthorize().'?'.$this->httpBuildQuery($params, '', '&');
     }
 
     // @codeCoverageIgnoreStart
-    public function authorize($options = [])
+    public function authorize($options = array())
     {
         $url = $this->getAuthorizationUrl($options);
         if ($this->redirectHandler) {
@@ -148,7 +148,7 @@ abstract class AbstractProvider implements ProviderInterface
         // @codeCoverageIgnoreEnd
     }
 
-    public function getAccessToken($grant = 'authorization_code', $params = [])
+    public function getAccessToken($grant = 'authorization_code', $params = array())
     {
         if (is_string($grant)) {
             // PascalCase the grant. E.g: 'authorization_code' becomes 'AuthorizationCode'

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -128,7 +128,7 @@ abstract class AbstractProvider implements ProviderInterface
             'state' => $this->state,
             'scope' => is_array($this->scopes) ? implode($this->scopeSeparator, $this->scopes) : $this->scopes,
             'response_type' => isset($options['response_type']) ? $options['response_type'] : 'code',
-            'approval_prompt' => isset($options['approval_prompt']) ? $options['approval_prompt'] : 'auto',
+            'approval_prompt' => isset($options['approval_prompt']) ? $options['approval_prompt'] : 'auto'
         );
 
         return $this->urlAuthorize().'?'.$this->httpBuildQuery($params, '', '&');

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -163,12 +163,12 @@ abstract class AbstractProvider implements ProviderInterface
             throw new \InvalidArgumentException($message);
         }
 
-        $defaultParams = [
+        $defaultParams = array(
             'client_id'     => $this->clientId,
             'client_secret' => $this->clientSecret,
             'redirect_uri'  => $this->redirectUri,
-            'grant_type'    => $grant,
-        ];
+            'grant_type'    => $grant
+        );
 
         $requestParams = $grant->prepRequestParams($defaultParams, $params);
 

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -23,7 +23,7 @@ abstract class AbstractProvider implements ProviderInterface
 
     public $uidKey = 'uid';
 
-    public $scopes = array()
+    public $scopes = array();
 
     public $method = 'post';
 

--- a/src/Provider/Eventbrite.php
+++ b/src/Provider/Eventbrite.php
@@ -9,9 +9,9 @@ class Eventbrite extends AbstractProvider
     public function __construct($options)
     {
         parent::__construct($options);
-        $this->headers = [
+        $this->headers = array(
             'Authorization' => 'Bearer',
-        ];
+        );
     }
 
     public function urlAuthorize()

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -51,8 +51,7 @@ class Facebook extends AbstractProvider
             'picture.type(large){url}',
             'gender',
             'locale',
-            'link')
-        );
+            'link'));
 
         return 'https://graph.facebook.com/'.$this->graphApiVersion.'/me?fields='.$fields.'&access_token='.$token;
     }
@@ -80,8 +79,7 @@ class Facebook extends AbstractProvider
             'imageurl' => $imageUrl,
             'gender' => $gender,
             'locale' => $locale,
-            'urls' => array( 'Facebook' => $response->link ))
-        );
+            'urls' => array( 'Facebook' => $response->link)));
 
         return $user;
     }

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -16,7 +16,7 @@ class Facebook extends AbstractProvider
      */
     protected $graphApiVersion;
 
-    public $scopes = ['public_profile', 'email'];
+    public $scopes = array('public_profile', 'email');
 
     public $responseType = 'string';
 
@@ -40,7 +40,7 @@ class Facebook extends AbstractProvider
 
     public function urlUserDetails(\League\OAuth2\Client\Token\AccessToken $token)
     {
-        $fields = implode(',', [
+        $fields = implode(',', array(
             'id',
             'name',
             'first_name',
@@ -52,7 +52,8 @@ class Facebook extends AbstractProvider
             'gender',
             'locale',
             'link',
-        ]);
+            )
+        );
 
         return 'https://graph.facebook.com/'.$this->graphApiVersion.'/me?fields='.$fields.'&access_token='.$token;
     }
@@ -80,7 +81,7 @@ class Facebook extends AbstractProvider
             'imageurl' => $imageUrl,
             'gender' => $gender,
             'locale' => $locale,
-            'urls' => [ 'Facebook' => $response->link ],
+            'urls' => array( 'Facebook' => $response->link ),
         ]);
 
         return $user;

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -51,7 +51,7 @@ class Facebook extends AbstractProvider
             'picture.type(large){url}',
             'gender',
             'locale',
-            'link',
+            'link'
             )
         );
 

--- a/src/Provider/Facebook.php
+++ b/src/Provider/Facebook.php
@@ -51,8 +51,7 @@ class Facebook extends AbstractProvider
             'picture.type(large){url}',
             'gender',
             'locale',
-            'link'
-            )
+            'link')
         );
 
         return 'https://graph.facebook.com/'.$this->graphApiVersion.'/me?fields='.$fields.'&access_token='.$token;
@@ -70,7 +69,7 @@ class Facebook extends AbstractProvider
         $gender = (isset($response->gender)) ? $response->gender : null;
         $locale = (isset($response->locale)) ? $response->locale : null;
 
-        $user->exchangeArray([
+        $user->exchangeArray(array(
             'uid' => $response->id,
             'name' => $response->name,
             'firstname' => $response->first_name,
@@ -81,8 +80,8 @@ class Facebook extends AbstractProvider
             'imageurl' => $imageUrl,
             'gender' => $gender,
             'locale' => $locale,
-            'urls' => array( 'Facebook' => $response->link ),
-        ]);
+            'urls' => array( 'Facebook' => $response->link ))
+        );
 
         return $user;
     }

--- a/src/Provider/Github.php
+++ b/src/Provider/Github.php
@@ -50,9 +50,9 @@ class Github extends AbstractProvider
             'nickname' => $response->login,
             'name' => $name,
             'email' => $email,
-            'urls'  => [
+            'urls'  => array(
                 'GitHub' => $this->domain.'/'.$response->login,
-            ],
+            ),
         ]);
 
         return $user;

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -103,7 +103,7 @@ class Google extends AbstractProvider
     public function userScreenName($response, \League\OAuth2\Client\Token\AccessToken $token)
     {
         return array(
-            $response->name->givenName, 
+            $response->name->givenName,
             $response->name->familyName
         );
     }

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -8,10 +8,10 @@ class Google extends AbstractProvider
 {
     public $scopeSeparator = ' ';
 
-    public $scopes = [
+    public $scopes = array(
         'profile',
         'email',
-    ];
+    );
 
     /**
      * @var string If set, this will be sent to google as the "hd" parameter.
@@ -102,7 +102,10 @@ class Google extends AbstractProvider
 
     public function userScreenName($response, \League\OAuth2\Client\Token\AccessToken $token)
     {
-        return [$response->name->givenName, $response->name->familyName];
+        return array(
+            $response->name->givenName, 
+            $response->name->familyName
+        );
     }
 
     public function getAuthorizationUrl($options = array())
@@ -110,11 +113,11 @@ class Google extends AbstractProvider
         $url = parent::getAuthorizationUrl($options);
 
         if (!empty($this->hostedDomain)) {
-            $url .= '&' . $this->httpBuildQuery(['hd' => $this->hostedDomain]);
+            $url .= '&' . $this->httpBuildQuery(array('hd' => $this->hostedDomain));
         }
 
         if (!empty($this->accessType)) {
-            $url .= '&' . $this->httpBuildQuery(['access_type'=> $this->accessType]);
+            $url .= '&' . $this->httpBuildQuery(array('access_type'=> $this->accessType));
         }
 
         return $url;

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -76,14 +76,13 @@ class Google extends AbstractProvider
             count($response['emails']) &&
             $response['emails'][0]->value)? $response['emails'][0]->value : null;
 
-        $user->exchangeArray([
+        $user->exchangeArray(array(
             'uid' => $response['id'],
             'name' => $response['displayName'],
             'firstname' => $response['name']->givenName,
             'lastName' => $response['name']->familyName,
             'email' => $email,
-            'imageUrl' => $imageUrl
-        ]);
+            'imageUrl' => $imageUrl));
 
         return $user;
     }

--- a/src/Provider/Google.php
+++ b/src/Provider/Google.php
@@ -10,7 +10,7 @@ class Google extends AbstractProvider
 
     public $scopes = array(
         'profile',
-        'email',
+        'email'
     );
 
     /**
@@ -82,7 +82,7 @@ class Google extends AbstractProvider
             'firstname' => $response['name']->givenName,
             'lastName' => $response['name']->familyName,
             'email' => $email,
-            'imageUrl' => $imageUrl,
+            'imageUrl' => $imageUrl
         ]);
 
         return $user;

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -35,8 +35,7 @@ class Instagram extends AbstractProvider
             'nickname' => $response->data->username,
             'name' => $response->data->full_name,
             'description' => $description,
-            'imageUrl' => $response->data->profile_picture
-            )
+            'imageUrl' => $response->data->profile_picture)
         );
 
         return $user;

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -35,8 +35,7 @@ class Instagram extends AbstractProvider
             'nickname' => $response->data->username,
             'name' => $response->data->full_name,
             'description' => $description,
-            'imageUrl' => $response->data->profile_picture)
-        );
+            'imageUrl' => $response->data->profile_picture));
 
         return $user;
     }

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -35,7 +35,7 @@ class Instagram extends AbstractProvider
             'nickname' => $response->data->username,
             'name' => $response->data->full_name,
             'description' => $description,
-            'imageUrl' => $response->data->profile_picture,
+            'imageUrl' => $response->data->profile_picture
             )
         );
 

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -6,7 +6,7 @@ use League\OAuth2\Client\Entity\User;
 
 class Instagram extends AbstractProvider
 {
-    public $scopes = ['basic'];
+    public $scopes = array('basic');
     public $responseType = 'json';
 
     public function urlAuthorize()
@@ -30,13 +30,14 @@ class Instagram extends AbstractProvider
 
         $description = (isset($response->data->bio)) ? $response->data->bio : null;
 
-        $user->exchangeArray([
+        $user->exchangeArray(array(
             'uid' => $response->data->id,
             'nickname' => $response->data->username,
             'name' => $response->data->full_name,
             'description' => $description,
             'imageUrl' => $response->data->profile_picture,
-        ]);
+            )
+        );
 
         return $user;
     }

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -48,7 +48,7 @@ class LinkedIn extends AbstractProvider
             'location' => $location,
             'description' => $description,
             'imageurl' => $pictureUrl,
-            'urls' => $response->publicProfileUrl,
+            'urls' => $response->publicProfileUrl
             )
         );
 

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -48,8 +48,7 @@ class LinkedIn extends AbstractProvider
             'location' => $location,
             'description' => $description,
             'imageurl' => $pictureUrl,
-            'urls' => $response->publicProfileUrl
-            )
+            'urls' => $response->publicProfileUrl)
         );
 
         return $user;

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -11,7 +11,7 @@ class LinkedIn extends AbstractProvider
     public $responseType = 'json';
     public $fields = array(
         'id', 'email-address', 'first-name', 'last-name', 'headline',
-        'location', 'industry', 'picture-url', 'public-profile-url',
+        'location', 'industry', 'picture-url', 'public-profile-url'
     );
 
     public function urlAuthorize()

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -48,8 +48,7 @@ class LinkedIn extends AbstractProvider
             'location' => $location,
             'description' => $description,
             'imageurl' => $pictureUrl,
-            'urls' => $response->publicProfileUrl)
-        );
+            'urls' => $response->publicProfileUrl));
 
         return $user;
     }

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -7,12 +7,12 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class LinkedIn extends AbstractProvider
 {
-    public $scopes = ['r_basicprofile r_emailaddress r_contactinfo'];
+    public $scopes = array('r_basicprofile r_emailaddress r_contactinfo');
     public $responseType = 'json';
-    public $fields = [
+    public $fields = array(
         'id', 'email-address', 'first-name', 'last-name', 'headline',
         'location', 'industry', 'picture-url', 'public-profile-url',
-    ];
+    );
 
     public function urlAuthorize()
     {
@@ -39,7 +39,7 @@ class LinkedIn extends AbstractProvider
         $description = (isset($response->headline)) ? $response->headline : null;
         $pictureUrl = (isset($response->pictureUrl)) ? $response->pictureUrl : null;
 
-        $user->exchangeArray([
+        $user->exchangeArray(array(
             'uid' => $response->id,
             'name' => $response->firstName.' '.$response->lastName,
             'firstname' => $response->firstName,
@@ -49,7 +49,8 @@ class LinkedIn extends AbstractProvider
             'description' => $description,
             'imageurl' => $pictureUrl,
             'urls' => $response->publicProfileUrl,
-        ]);
+            )
+        );
 
         return $user;
     }
@@ -68,6 +69,9 @@ class LinkedIn extends AbstractProvider
 
     public function userScreenName($response, AccessToken $token)
     {
-        return [$response->firstName, $response->lastName];
+        return array(
+            $response->firstName,
+            $response->lastName
+        );
     }
 }

--- a/src/Provider/Microsoft.php
+++ b/src/Provider/Microsoft.php
@@ -7,7 +7,7 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class Microsoft extends AbstractProvider
 {
-    public $scopes = ['wl.basic', 'wl.emails'];
+    public $scopes = array('wl.basic', 'wl.emails');
     public $responseType = 'json';
 
     public function urlAuthorize()
@@ -37,7 +37,7 @@ class Microsoft extends AbstractProvider
 
         $email = (isset($response->emails->preferred)) ? $response->emails->preferred : null;
 
-        $user->exchangeArray([
+        $user->exchangeArray(array(
             'uid' => $response->id,
             'name' => $response->name,
             'firstname' => $response->first_name,
@@ -45,7 +45,7 @@ class Microsoft extends AbstractProvider
             'email' => $email,
             'imageurl' => $imageUrl,
             'urls' => $response->link.'/cid-'.$response->id,
-        ]);
+        ));
 
         return $user;
     }
@@ -64,6 +64,6 @@ class Microsoft extends AbstractProvider
 
     public function userScreenName($response, AccessToken $token)
     {
-        return [$response->first_name, $response->last_name];
+        return array($response->first_name, $response->last_name);
     }
 }

--- a/src/Provider/ProviderInterface.php
+++ b/src/Provider/ProviderInterface.php
@@ -18,11 +18,11 @@ interface ProviderInterface
 
     public function setScopes(array $scopes);
 
-    public function getAuthorizationUrl($options = []);
+    public function getAuthorizationUrl($options = array());
 
-    public function authorize($options = []);
+    public function authorize($options = array());
 
-    public function getAccessToken($grant = 'authorization_code', $params = []);
+    public function getAccessToken($grant = 'authorization_code', $params = array());
 
     public function getUserDetails(AccessToken $token);
 

--- a/test/src/Entity/UserTest.php
+++ b/test/src/Entity/UserTest.php
@@ -14,7 +14,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
     {
         $this->user = new User();
 
-        $this->userArray = [
+        $this->userArray = array(
             'uid' => 'mock_uid',
             'nickname' => 'mock_nickname',
             'name' => 'mock_name',
@@ -27,7 +27,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
             'urls' => 'mock_urls',
             'gender' => 'mock_gender',
             'locale' => 'mock_locale',
-        ];
+        );
     }
 
     public function testExchangeArrayGetArrayCopy()

--- a/test/src/Exception/IDPExceptionTest.php
+++ b/test/src/Exception/IDPExceptionTest.php
@@ -23,7 +23,7 @@ class IDPExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function testGetTypeEmpty()
     {
-        $exception = new IDPException([]);
+        $exception = new IDPException(array());
 
         $this->assertEquals('Exception', $exception->getType());
     }

--- a/test/src/Grant/AuthorizationCodeTest.php
+++ b/test/src/Grant/AuthorizationCodeTest.php
@@ -10,11 +10,11 @@ class AuthorizationCodeTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Google([
+        $this->provider = new \League\OAuth2\Client\Provider\Google(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+        ));
     }
 
     public function tearDown()
@@ -34,6 +34,6 @@ class AuthorizationCodeTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidRefreshToken()
     {
-        $this->provider->getAccessToken('authorization_code', ['invalid_code' => 'mock_authorization_code']);
+        $this->provider->getAccessToken('authorization_code', array('invalid_code' => 'mock_authorization_code'));
     }
 }

--- a/test/src/Grant/ClientCredentialsTest.php
+++ b/test/src/Grant/ClientCredentialsTest.php
@@ -14,7 +14,8 @@ class ClientCredentialsTest extends \PHPUnit_Framework_TestCase
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ));
+            )
+        );
     }
 
     public function tearDown()

--- a/test/src/Grant/PasswordTest.php
+++ b/test/src/Grant/PasswordTest.php
@@ -14,7 +14,8 @@ class PasswordTest extends \PHPUnit_Framework_TestCase
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ));
+            )
+        );
     }
 
     public function tearDown()

--- a/test/src/Grant/RefreshTokenTest.php
+++ b/test/src/Grant/RefreshTokenTest.php
@@ -10,11 +10,12 @@ class RefreshTokenTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Google([
+        $this->provider = new \League\OAuth2\Client\Provider\Google(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -33,13 +34,13 @@ class RefreshTokenTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(2)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $this->assertInstanceOf('League\OAuth2\Client\Token\AccessToken', $token);
 
         $grant = new \League\OAuth2\Client\Grant\RefreshToken();
         $this->assertEquals('refresh_token', (string) $grant);
 
-        $newToken = $this->provider->getAccessToken($grant, ['refresh_token' => $token->refreshToken]);
+        $newToken = $this->provider->getAccessToken($grant, array('refresh_token' => $token->refreshToken));
         $this->assertInstanceOf('League\OAuth2\Client\Token\AccessToken', $newToken);
     }
 
@@ -56,9 +57,9 @@ class RefreshTokenTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $grant = new \League\OAuth2\Client\Grant\RefreshToken();
-        $refreshToken = $this->provider->getAccessToken($grant, ['invalid_refresh_token' => $token->refreshToken]);
+        $refreshToken = $this->provider->getAccessToken($grant, array('invalid_refresh_token' => $token->refreshToken));
     }
 }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -15,11 +15,12 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Google([
+        $this->provider = new \League\OAuth2\Client\Provider\Google(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -33,7 +34,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidGrantString()
     {
-        $this->provider->getAccessToken('invalid_grant', ['invalid_parameter' => 'none']);
+        $this->provider->getAccessToken('invalid_grant', array('invalid_parameter' => 'none'));
     }
 
     /**
@@ -42,14 +43,17 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     public function testInvalidGrantObject()
     {
         $grant = new \StdClass();
-        $this->provider->getAccessToken($grant, ['invalid_parameter' => 'none']);
+        $this->provider->getAccessToken($grant, array('invalid_parameter' => 'none'));
     }
 
     public function testAuthorizationUrlStateParam()
     {
-        $this->assertContains('state=XXX', $this->provider->getAuthorizationUrl([
-            'state' => 'XXX'
-        ]));
+        $this->assertContains('state=XXX', $this->provider->getAuthorizationUrl(
+                array(
+                'state' => 'XXX'
+                )
+            )
+        );
     }
 
     /**
@@ -57,19 +61,19 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorSetsProperties()
     {
-        $options = [
+        $options = array(
             'clientId' => '1234',
             'clientSecret' => '4567',
             'redirectUri' => 'http://example.org/redirect',
             'state' => 'foo',
             'name' => 'bar',
             'uidKey' => 'mynewuid',
-            'scopes' => ['a', 'b', 'c'],
+            'scopes' => array('a', 'b', 'c'),
             'method' => 'get',
             'scopeSeparator' => ';',
             'responseType' => 'csv',
-            'headers' => ['Foo' => 'Bar'],
-        ];
+            'headers' => array('Foo' => 'Bar'),
+        );
 
         $mockProvider = new MockProvider($options);
 
@@ -100,17 +104,17 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetUserProperties($response, $name = null, $email = null, $id = null)
     {
-        $token = new AccessToken(['access_token' => 'abc', 'expires_in' => 3600]);
+        $token = new AccessToken(array('access_token' => 'abc', 'expires_in' => 3600));
 
         $provider = $this->getMockForAbstractClass(
             '\League\OAuth2\Client\Provider\AbstractProvider',
-            [
-              [
+            array(
+              array(
                   'clientId'     => 'mock_client_id',
                   'clientSecret' => 'mock_secret',
                   'redirectUri'  => 'none',
-              ]
-            ]
+              )
+            )
         );
 
         /**
@@ -136,11 +140,11 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response3 = new \stdClass();
 
-        return [
-            [$response, 'test', 'test@example.com', 1],
-            [$response2],
-            [$response3],
-        ];
+        return array(
+            array($response, 'test', 'test@example.com', 1),
+            array($response2),
+            array($response3),
+        );
     }
 }
 

--- a/test/src/Provider/EventbriteTest.php
+++ b/test/src/Provider/EventbriteTest.php
@@ -10,11 +10,12 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Eventbrite([
+        $this->provider = new \League\OAuth2\Client\Provider\Eventbrite(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -56,7 +57,7 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals('mock_access_token', $token->accessToken);
         $this->assertLessThanOrEqual(time() + 3600, $token->expires);
@@ -67,7 +68,7 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals([], $this->provider->getScopes());
+        $this->assertEquals(array(), $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -85,7 +86,7 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('setDefaultOption')->times(4);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));

--- a/test/src/Provider/FacebookTest.php
+++ b/test/src/Provider/FacebookTest.php
@@ -72,7 +72,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     public function testGraphApiVersionWillFallbackToDefault()
     {
         $graphVersion = \League\OAuth2\Client\Provider\Facebook::DEFAULT_GRAPH_VERSION;
-        $fooToken = new \League\OAuth2\Client\Token\AccessToken(['access_token' => 'foo_token']);
+        $fooToken = new \League\OAuth2\Client\Token\AccessToken(array('access_token' => 'foo_token'));
 
         $urlAuthorize = $this->provider->urlAuthorize();
         $urlAccessToken = $this->provider->urlAccessToken();

--- a/test/src/Provider/FacebookTest.php
+++ b/test/src/Provider/FacebookTest.php
@@ -13,11 +13,12 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Facebook([
+        $this->provider = new \League\OAuth2\Client\Provider\Facebook(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -53,10 +54,11 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
     public function testGraphApiVersionCanBeCustomized()
     {
         $graphVersion = 'v13.37';
-        $provider = new \League\OAuth2\Client\Provider\Facebook([
+        $provider = new \League\OAuth2\Client\Provider\Facebook(array(
             'graphApiVersion' => $graphVersion,
-        ]);
-        $fooToken = new \League\OAuth2\Client\Token\AccessToken(['access_token' => 'foo_token']);
+            )
+        );
+        $fooToken = new \League\OAuth2\Client\Token\AccessToken(array('access_token' => 'foo_token'));
 
         $urlAuthorize = $provider->urlAuthorize();
         $urlAccessToken = $provider->urlAccessToken();
@@ -91,7 +93,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals('mock_access_token', $token->accessToken);
         $this->assertLessThanOrEqual(time() + 3600, $token->expires);
@@ -102,7 +104,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals(['public_profile', 'email'], $this->provider->getScopes());
+        $this->assertEquals(array('public_profile', 'email'), $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -112,7 +114,7 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
         $getResponse->shouldReceive('getBody')->andReturn('{"id": 12345, "name": "mock_name", "username": "mock_username", "first_name": "mock_first_name", "last_name": "mock_last_name", "email": "mock_email", "Location": "mock_home", "bio": "mock_description", "link": "mock_facebook_url"}');
-        $getResponse->shouldReceive('getInfo')->andReturn(['url' => 'mock_image_url']);
+        $getResponse->shouldReceive('getInfo')->andReturn(array('url' => 'mock_image_url'));
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(5);
@@ -120,11 +122,11 @@ class FacebookTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('get->send')->andReturn($getResponse);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));
-        $this->assertEquals(['mock_first_name', 'mock_last_name'], $this->provider->getUserScreenName($token));
+        $this->assertEquals(array('mock_first_name', 'mock_last_name'), $this->provider->getUserScreenName($token));
         $this->assertEquals('mock_email', $this->provider->getUserEmail($token));
         $this->assertEquals('mock_email', $user->email);
     }

--- a/test/src/Provider/GithubTest.php
+++ b/test/src/Provider/GithubTest.php
@@ -89,7 +89,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->provider->setScopes(array(['user', 'repo']));
+        $this->provider->setScopes(array('user', 'repo'));
         $this->assertEquals(array('user', 'repo'), $this->provider->getScopes());
     }
 

--- a/test/src/Provider/GithubTest.php
+++ b/test/src/Provider/GithubTest.php
@@ -89,7 +89,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->provider->setScopes(['user', 'repo']);
+        $this->provider->setScopes(array(['user', 'repo']));
         $this->assertEquals(array('user', 'repo'), $this->provider->getScopes());
     }
 

--- a/test/src/Provider/GithubTest.php
+++ b/test/src/Provider/GithubTest.php
@@ -10,11 +10,12 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Github([
+        $this->provider = new \League\OAuth2\Client\Provider\Github(array(
             'clientId' => 'mock',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -56,7 +57,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals('mock_access_token', $token->accessToken);
         $this->assertLessThanOrEqual(time() + 3600, $token->expires);
@@ -77,7 +78,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals('mock_access_token', $token->accessToken);
         $this->assertLessThanOrEqual(time() + 3600, $token->expires);
@@ -89,7 +90,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
     public function testScopes()
     {
         $this->provider->setScopes(['user', 'repo']);
-        $this->assertEquals(['user', 'repo'], $this->provider->getScopes());
+        $this->assertEquals(array('user', 'repo'), $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -106,7 +107,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));
@@ -124,7 +125,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('setBaseUrl')->times(1);
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals($this->provider->domain.'/login/oauth/authorize', $this->provider->urlAuthorize());
         $this->assertEquals($this->provider->domain.'/login/oauth/access_token', $this->provider->urlAccessToken());
@@ -143,7 +144,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('setBaseUrl')->times(1);
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals($this->provider->domain.'/login/oauth/authorize', $this->provider->urlAuthorize());
         $this->assertEquals($this->provider->domain.'/login/oauth/access_token', $this->provider->urlAccessToken());
@@ -165,7 +166,7 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('get->send')->times(1)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $emails = $this->provider->getUserEmails($token);
         $this->assertInternalType('array', $emails);
         $this->assertCount(3, $emails);

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -10,7 +10,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Google(array()
+        $this->provider = new \League\OAuth2\Client\Provider\Google(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -10,13 +10,14 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Google([
+        $this->provider = new \League\OAuth2\Client\Provider\Google(array()
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
             'hostedDomain' => 'mock_domain',
             'accessType' => 'mock_access_type'
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -60,7 +61,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
 #    print_r($token);die();
 
@@ -73,7 +74,7 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals(['profile', 'email'], $this->provider->getScopes());
+        $this->assertEquals(array('profile', 'email'), $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -90,11 +91,11 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));
-        $this->assertEquals(['mock_first_name', 'mock_last_name'], $this->provider->getUserScreenName($token));
+        $this->assertEquals(array('mock_first_name', 'mock_last_name'), $this->provider->getUserScreenName($token));
         $this->assertEquals('mock_email', $this->provider->getUserEmail($token));
         $this->assertEquals('mock_email', $user->email);
     }

--- a/test/src/Provider/InstagramTest.php
+++ b/test/src/Provider/InstagramTest.php
@@ -10,11 +10,12 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Instagram([
+        $this->provider = new \League\OAuth2\Client\Provider\Instagram(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -56,7 +57,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
 #    print_r($token);die();
 
@@ -69,7 +70,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals(['basic'], $this->provider->getScopes());
+        $this->assertEquals(array('basic'), $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -86,7 +87,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));

--- a/test/src/Provider/InstagramTest.php
+++ b/test/src/Provider/InstagramTest.php
@@ -13,9 +13,7 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
         $this->provider = new \League\OAuth2\Client\Provider\Instagram(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
-            'redirectUri' => 'none',
-            )
-        );
+            'redirectUri' => 'none'));
     }
 
     public function tearDown()

--- a/test/src/Provider/LinkedInTest.php
+++ b/test/src/Provider/LinkedInTest.php
@@ -10,11 +10,12 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\LinkedIn([
+        $this->provider = new \League\OAuth2\Client\Provider\LinkedIn(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -56,7 +57,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
 #    print_r($token);die();
 
@@ -69,7 +70,7 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals(['r_basicprofile r_emailaddress r_contactinfo'], $this->provider->getScopes());
+        $this->assertEquals(array('r_basicprofile r_emailaddress r_contactinfo'), $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -86,11 +87,11 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));
-        $this->assertEquals(['mock_first_name', 'mock_last_name'], $this->provider->getUserScreenName($token));
+        $this->assertEquals(array('mock_first_name', 'mock_last_name'), $this->provider->getUserScreenName($token));
         $this->assertEquals('mock_email', $this->provider->getUserEmail($token));
         $this->assertEquals('mock_email', $user->email);
     }

--- a/test/src/Provider/MicrosoftTest.php
+++ b/test/src/Provider/MicrosoftTest.php
@@ -101,7 +101,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));
-        $this->assertEquals(['mock_first_name', 'mock_last_name'], $this->provider->getUserScreenName($token));
+        $this->assertEquals(array('mock_first_name', 'mock_last_name'), $this->provider->getUserScreenName($token));
         $this->assertEquals('mock_email', $this->provider->getUserEmail($token));
         $this->assertEquals('mock_email', $user->email);
         $this->assertEquals('mock_image_url', $user->imageUrl);

--- a/test/src/Provider/MicrosoftTest.php
+++ b/test/src/Provider/MicrosoftTest.php
@@ -10,11 +10,12 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Microsoft([
+        $this->provider = new \League\OAuth2\Client\Provider\Microsoft(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
             'redirectUri' => 'none',
-        ]);
+            )
+        );
     }
 
     public function tearDown()
@@ -64,7 +65,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
 #    print_r($token);die();
 
@@ -77,7 +78,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals(['wl.basic', 'wl.emails'], $this->provider->getScopes());
+        $this->assertEquals(array('wl.basic', 'wl.emails'), $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -96,7 +97,7 @@ class MicrosoftTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('get->send')->times(5)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));

--- a/test/src/Provider/VkontakteTest.php
+++ b/test/src/Provider/VkontakteTest.php
@@ -10,11 +10,10 @@ class VkontakteTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->provider = new \League\OAuth2\Client\Provider\Vkontakte([
+        $this->provider = new \League\OAuth2\Client\Provider\Vkontakte(array(
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
-            'redirectUri' => 'none',
-        ]);
+            'redirectUri' => 'none'));
     }
 
     public function tearDown()
@@ -56,7 +55,7 @@ class VkontakteTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('post->send')->times(1)->andReturn($response);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
 
         $this->assertEquals('mock_access_token', $token->accessToken);
         $this->assertLessThanOrEqual(time() + 3600, $token->expires);
@@ -67,7 +66,7 @@ class VkontakteTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals([], $this->provider->getScopes());
+        $this->assertEquals(array(), $this->provider->getScopes());
     }
 
     public function testUserData()
@@ -84,11 +83,11 @@ class VkontakteTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
 
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $token = $this->provider->getAccessToken('authorization_code', array('code' => 'mock_authorization_code'));
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals(12345, $this->provider->getUserUid($token));
-        $this->assertEquals(['mock_first_name', 'mock_last_name'], $this->provider->getUserScreenName($token));
+        $this->assertEquals(array('mock_first_name', 'mock_last_name'), $this->provider->getUserScreenName($token));
         $this->assertEquals('mock_email', $this->provider->getUserEmail($token));
         $this->assertEquals('mock_email', $user->email);
     }

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -9,7 +9,7 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidRefreshToken()
     {
-        new \League\OAuth2\Client\Token\AccessToken(['invalid_access_token' => 'none']);
+        new \League\OAuth2\Client\Token\AccessToken(array('invalid_access_token' => 'none'));
     }
 
     public function testExpiresInCorrection()


### PR DESCRIPTION
I don't know if its currently enough justs to replace short array tags with array().

But it is currently a showstopper to have oauth2-client not php5.3 compatible.

If you don't like php5.3 compatibilty in your master branch, please add a php5.3 branch thats created and updated to composer on every release too.

The fix of the camelcase name bug in version 0.3 is not included. I think the better way is to update current version to support also php5.3 and let php5.3 users profit from current oauth2-client development.