### PR TITLE
[Fix] Invalid JSON in response will trigger fatal error

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -205,6 +205,11 @@ abstract class AbstractProvider implements ProviderInterface
         switch ($this->responseType) {
             case 'json':
                 $result = json_decode($response, true);
+
+                if (JSON_ERROR_NONE !== json_last_error()) {
+                    $result = [];
+                }
+
                 break;
             case 'string':
                 parse_str($response, $result);

--- a/test/src/Provider/GithubTest.php
+++ b/test/src/Provider/GithubTest.php
@@ -65,6 +65,25 @@ class GithubTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('1', $token->uid);
     }
 
+    /**
+     * @ticket 230
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Required option not passed: access_token
+     */
+    public function testGetAccessTokenWithInvalidJson()
+    {
+        $response = m::mock('Guzzle\Http\Message\Response');
+        $response->shouldReceive('getBody')->times(1)->andReturn('invalid');
+
+        $client = m::mock('Guzzle\Service\Client');
+        $client->shouldReceive('setBaseUrl')->times(1);
+        $client->shouldReceive('post->send')->times(1)->andReturn($response);
+        $this->provider->setHttpClient($client);
+        $this->provider->responseType = 'json';
+
+        $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
+
     public function testGetAccessTokenSetResultUid()
     {
         $this->provider->uidKey = 'otherKey';


### PR DESCRIPTION
If the server responded with an invalid JSON for `getAccessToken()`,
$result variable will be of type string instead of expected array.
This will result in a fatal error was being raised in AbstractProvider
when calling `prepareAccessTokenResult` method, which expects an
argument of type array.

Proposed solution is to set the variable `$result` to an empty array if
json_decode was not successful.

Doesn't make sense to throw an expection at this point, because response
will not have an access_token and an `InvalidArgumentException` will be
thrown latter when `$grant->handleResponse()` will be called.

Fix #230