### PR TITLE
Adding Uber provider and tests

### DIFF
--- a/src/Provider/Uber.php
+++ b/src/Provider/Uber.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace League\OAuth2\Client\Provider;
+
+use League\OAuth2\Client\Entity\User;
+use League\OAuth2\Client\Token\AccessToken;
+
+class Uber extends AbstractProvider
+{
+    public $scopes = [];
+    public $responseType = 'json';
+    public $authorizationHeader = 'Bearer';
+    public $version = 'v1';
+
+    public function urlAuthorize()
+    {
+        return 'https://login.uber.com/oauth/authorize';
+    }
+
+    public function urlAccessToken()
+    {
+        return 'https://login.uber.com/oauth/token';
+    }
+
+    public function urlUserDetails(AccessToken $token)
+    {
+        return 'https://api.uber.com/'.$this->version.'/me';
+    }
+
+    public function userDetails($response, AccessToken $token)
+    {
+        $user = new User();
+
+        $user->exchangeArray([
+            'uid' => $response->uuid,
+            'name' => $response->first_name . ' ' . $response->last_name,
+            'firstname' => $response->first_name,
+            'lastname' => $response->last_name,
+            'email' => $response->email,
+            'imageUrl' => $response->picture,
+        ]);
+
+        return $user;
+    }
+
+    public function userUid($response, AccessToken $token)
+    {
+        return $response->uuid;
+    }
+
+    public function userEmail($response, AccessToken $token)
+    {
+        return $response->email;
+    }
+
+    public function userScreenName($response, AccessToken $token)
+    {
+        return [$response->first_name, $response->last_name];
+    }
+}

--- a/src/Provider/Uber.php
+++ b/src/Provider/Uber.php
@@ -12,21 +12,50 @@ class Uber extends AbstractProvider
     public $authorizationHeader = 'Bearer';
     public $version = 'v1';
 
+    /**
+     * Get the URL that this provider uses to begin authorization.
+     *
+     * @return string
+     */
     public function urlAuthorize()
     {
         return 'https://login.uber.com/oauth/authorize';
     }
 
+    /**
+     * Get the URL that this provider users to request an access token.
+     *
+     * @return string
+     */
     public function urlAccessToken()
     {
         return 'https://login.uber.com/oauth/token';
     }
 
+    /**
+     * Get the URL that this provider uses to request user details.
+     *
+     * Since this URL is typically an authorized route, most providers will require you to pass the access_token as
+     * a parameter to the request. For example, the google url is:
+     *
+     * 'https://www.googleapis.com/oauth2/v1/userinfo?alt=json&access_token='.$token
+     *
+     * @param AccessToken $token
+     * @return string
+     */
     public function urlUserDetails(AccessToken $token)
     {
         return 'https://api.uber.com/'.$this->version.'/me';
     }
 
+    /**
+     * Given an object response from the server, process the user details into a format expected by the user
+     * of the client.
+     *
+     * @param object $response
+     * @param AccessToken $token
+     * @return mixed
+     */
     public function userDetails($response, AccessToken $token)
     {
         $user = new User();

--- a/src/Provider/Uber.php
+++ b/src/Provider/Uber.php
@@ -55,6 +55,6 @@ class Uber extends AbstractProvider
 
     public function userScreenName($response, AccessToken $token)
     {
-        return [$response->first_name, $response->last_name];
+        return null;
     }
 }

--- a/test/src/Provider/UberTest.php
+++ b/test/src/Provider/UberTest.php
@@ -90,7 +90,6 @@ class UberTest extends \PHPUnit_Framework_TestCase
 
         $getResponse = m::mock('Guzzle\Http\Message\Response');
         $getResponse->shouldReceive('getBody')->times(4)->andReturn('{"first_name": "mock_first_name","last_name": "mock_last_name","email": "mock_email","picture": "mock_image_url","promo_code": "teypo","uuid": "mock_id"}');
-        $getResponse->shouldReceive('getInfo')->andReturn(array('url' => 'mock_image_url'));
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setDefaultOption')->times(4);
@@ -103,7 +102,7 @@ class UberTest extends \PHPUnit_Framework_TestCase
         $user = $this->provider->getUserDetails($token);
 
         $this->assertEquals('mock_id', $this->provider->getUserUid($token));
-        $this->assertEquals(['mock_first_name', 'mock_last_name'], $this->provider->getUserScreenName($token));
+        $this->assertNull($this->provider->getUserScreenName($token));
         $this->assertEquals('mock_email', $this->provider->getUserEmail($token));
         $this->assertEquals('mock_email', $user->email);
         $this->assertEquals('mock_image_url', $user->imageUrl);

--- a/test/src/Provider/UberTest.php
+++ b/test/src/Provider/UberTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace League\OAuth2\Client\Test\Provider;
+
+use Mockery as m;
+
+class UberTest extends \PHPUnit_Framework_TestCase
+{
+    protected $provider;
+
+    protected function setUp()
+    {
+        $this->provider = new \League\OAuth2\Client\Provider\Uber([
+            'clientId' => 'mock_client_id',
+            'clientSecret' => 'mock_secret',
+            'redirectUri' => 'none',
+        ]);
+    }
+
+    public function tearDown()
+    {
+        m::close();
+        parent::tearDown();
+    }
+
+    public function testAuthorizationUrl()
+    {
+        $url = $this->provider->getAuthorizationUrl();
+        $uri = parse_url($url);
+        parse_str($uri['query'], $query);
+
+        $this->assertArrayHasKey('client_id', $query);
+        $this->assertArrayHasKey('redirect_uri', $query);
+        $this->assertArrayHasKey('state', $query);
+        $this->assertArrayHasKey('scope', $query);
+        $this->assertArrayHasKey('response_type', $query);
+        $this->assertArrayHasKey('approval_prompt', $query);
+        $this->assertNotNull($this->provider->state);
+    }
+
+    public function testUrlAuthorize()
+    {
+        $url = $this->provider->urlAuthorize();
+        $uri = parse_url($url);
+
+        $this->assertEquals('/oauth/authorize', $uri['path']);
+    }
+
+    public function testUrlAccessToken()
+    {
+        $url = $this->provider->urlAccessToken();
+        $uri = parse_url($url);
+
+        $this->assertEquals('/oauth/token', $uri['path']);
+    }
+
+    public function testGetAccessToken()
+    {
+        $response = m::mock('Guzzle\Http\Message\Response');
+        $response->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}');
+
+        $client = m::mock('Guzzle\Service\Client');
+        $client->shouldReceive('setBaseUrl')->times(1);
+        $client->shouldReceive('post->send')->times(1)->andReturn($response);
+        $this->provider->setHttpClient($client);
+
+        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+
+        $this->assertEquals('mock_access_token', $token->accessToken);
+        $this->assertLessThanOrEqual(time() + 3600, $token->expires);
+        $this->assertGreaterThanOrEqual(time(), $token->expires);
+        $this->assertEquals('mock_refresh_token', $token->refreshToken);
+        $this->assertEquals('1', $token->uid);
+    }
+
+    public function testScopes()
+    {
+        $this->assertEmpty($this->provider->getScopes());
+    }
+
+    public function testAuthorizationHeader()
+    {
+        $this->assertEquals('Bearer', $this->provider->authorizationHeader);
+    }
+
+    public function testUserData()
+    {
+        $postResponse = m::mock('Guzzle\Http\Message\Response');
+        $postResponse->shouldReceive('getBody')->times(1)->andReturn('{"access_token": "mock_access_token","token_type": "Bearer","expires_in": "mock_expires","refresh_token": "mock_refresh_token","scope": "scope1 scope2"}');
+
+        $getResponse = m::mock('Guzzle\Http\Message\Response');
+        $getResponse->shouldReceive('getBody')->times(4)->andReturn('{"first_name": "mock_first_name","last_name": "mock_last_name","email": "mock_email","picture": "mock_image_url","promo_code": "teypo","uuid": "mock_id"}');
+        $getResponse->shouldReceive('getInfo')->andReturn(array('url' => 'mock_image_url'));
+
+        $client = m::mock('Guzzle\Service\Client');
+        $client->shouldReceive('setDefaultOption')->times(4);
+        $client->shouldReceive('setBaseUrl')->times(5);
+        $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
+        $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
+        $this->provider->setHttpClient($client);
+
+        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $user = $this->provider->getUserDetails($token);
+
+        $this->assertEquals('mock_id', $this->provider->getUserUid($token));
+        $this->assertEquals(['mock_first_name', 'mock_last_name'], $this->provider->getUserScreenName($token));
+        $this->assertEquals('mock_email', $this->provider->getUserEmail($token));
+        $this->assertEquals('mock_email', $user->email);
+        $this->assertEquals('mock_image_url', $user->imageUrl);
+    }
+}


### PR DESCRIPTION
Uber now has an API that utilizes OAuth2. This proposal includes a provider and supporting tests to offer support for Uber.