### PR TITLE
Add link to third-party Coinbase OAuth2 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ so please help them out with a pull request if you notice this.
 
 - [Auth0](https://github.com/RiskioFr/oauth2-auth0)
 - [Battle.net](https://packagist.org/packages/depotwarehouse/oauth2-bnet)
+- [Coinbase](https://github.com/openclerk/coinbase-oauth2)
 - [Dropbox](https://github.com/pixelfear/oauth2-dropbox)
 - [FreeAgent](https://github.com/CloudManaged/oauth2-freeagent)
 - [Google Nest](https://github.com/JC5/nest-oauth2-provider)


### PR DESCRIPTION
Provided by https://github.com/openclerk/coinbase-oauth2