### PR TITLE
Fixed headers being parsed incorrectly

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -342,7 +342,7 @@ abstract class AbstractProvider implements ProviderInterface
         try {
             $client = $this->getHttpClient();
 
-            $httpResponse = $client->get($url, ['headers' => $headers]);
+            $httpResponse = $client->get($url, $headers);
 
             $response = (string) $httpResponse->getBody();
         } catch (HttpAdapterException $e) {


### PR DESCRIPTION
As mentioned in #237 authentication headers would be wrapped in a 'headers' header.