### PR TITLE
send  param in redirectHandler

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -143,7 +143,7 @@ abstract class AbstractProvider implements ProviderInterface
         $url = $this->getAuthorizationUrl($options);
         if ($this->redirectHandler) {
             $handler = $this->redirectHandler;
-            return $handler($url);
+            return $handler($url, $this);
         }
         // @codeCoverageIgnoreStart
         header('Location: ' . $url);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -90,16 +90,19 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     public function testSetRedirectHandler()
     {
         $this->testFunction = false;
+        $this->state = false;
 
-        $callback = function ($url) {
+        $callback = function ($url, $provider) {
             $this->testFunction = $url;
+            $this->state = $provider->state;
         };
 
         $this->provider->setRedirectHandler($callback);
 
-        $this->provider->authorize('http://test.url/');
+        $this->provider->authorize();
 
         $this->assertNotFalse($this->testFunction);
+        $this->assertEquals($this->provider->state, $this->state);
     }
 
     /**


### PR DESCRIPTION
add a param to redirectHandler, so we can easily get state and so on in redirectHandler.

```php
$provider->setRedirectHandler(function($url, $provider){
    $_SESSION['oauth2state'] = $provider->state;
    header('Location: '.$url);
    exit;
}
```
