### PR TITLE
Exception handle

### DIFF
--- a/src/Exception/IDPException.php
+++ b/src/Exception/IDPException.php
@@ -6,20 +6,24 @@ class IDPException extends \Exception
 {
     protected $result;
 
-    public function __construct($result)
+    public function __construct($result, $message = null, $code = null)
     {
         $this->result = $result;
 
-        $code = isset($result['code']) ? $result['code'] : 0;
+        if (!$code) {
+            $code = isset($result['code']) ? $result['code'] : 0;
+        }
 
-        if (isset($result['error']) && $result['error'] !== '') {
-            // OAuth 2.0 Draft 10 style
-            $message = $result['error'];
-        } elseif (isset($result['message']) && $result['message'] !== '') {
-            // cURL style
-            $message = $result['message'];
-        } else {
-            $message = 'Unknown Error.';
+        if (!$message) {
+            if (isset($result['error']) && $result['error'] !== '') {
+                // OAuth 2.0 Draft 10 style
+                $message = $result['error'];
+            } elseif (isset($result['message']) && $result['message'] !== '') {
+                // cURL style
+                $message = $result['message'];
+            } else {
+                $message = 'Unknown Error.';
+            }
         }
 
         parent::__construct($message, $code);

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -43,6 +43,8 @@ abstract class AbstractProvider implements ProviderInterface
 
     protected $redirectHandler;
 
+    protected $errorChecker;
+
     /**
      * @var int This represents: PHP_QUERY_RFC1738, which is the default value for php 5.4
      *          and the default encryption type for the http_build_query setup
@@ -58,6 +60,14 @@ abstract class AbstractProvider implements ProviderInterface
         }
 
         $this->setHttpClient($httpClient ?: new CurlHttpAdapter());
+
+        if (!isset($options['errorChecker'])) {
+            $this->setErrorChecker(function ($result) {
+                if (isset($result['error']) && ! empty($result['error'])) {
+                    throw new IDPException($result);
+                }
+            });
+        }
     }
 
     public function setHttpClient(HttpAdapterInterface $client)
@@ -217,12 +227,8 @@ abstract class AbstractProvider implements ProviderInterface
 
                 break;
         }
-
-        if (isset($result['error']) && ! empty($result['error'])) {
-            // @codeCoverageIgnoreStart
-            throw new IDPException($result);
-            // @codeCoverageIgnoreEnd
-        }
+        $checker = $this->errorChecker;
+        $checker($result);
 
         $result = $this->prepareAccessTokenResult($result);
 
@@ -376,5 +382,10 @@ abstract class AbstractProvider implements ProviderInterface
     public function setRedirectHandler(Closure $handler)
     {
         $this->redirectHandler = $handler;
+    }
+
+    public function setErrorChecker(Closure $checker)
+    {
+        $this->errorChecker = $checker;
     }
 }

--- a/test/src/Exception/IDPExceptionTest.php
+++ b/test/src/Exception/IDPExceptionTest.php
@@ -35,11 +35,25 @@ class IDPExceptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('message: message', (string)$exception);
     }
 
+    public function testAsStringCustom()
+    {
+        $exception = new IDPException(array('custom_error' => 'message'), 'message');
+
+        $this->assertEquals('Exception: message', (string)$exception);
+    }
+
     public function testAsStringWithCode()
     {
         $exception = new IDPException(array('error' => 'message', 'code' => 404));
 
         $this->assertEquals('message: 404: message', (string)$exception);
+    }
+
+    public function testAsStringWithCodeCustom()
+    {
+        $exception = new IDPException(array('custom_error' => 'message', 'custom_code' => 404), 'message', 404);
+
+        $this->assertEquals('Exception: 404: message', (string)$exception);
     }
 
     public function testGetResponseBody()
@@ -50,6 +64,19 @@ class IDPExceptionTest extends \PHPUnit_Framework_TestCase
             [
                 'error' => 'message',
                 'code'  => 404
+            ],
+            $exception->getResponseBody()
+        );
+    }
+
+    public function testGetResponseBodyCustom()
+    {
+        $exception = new IDPException(array('custom_error' => 'message', 'custom_code' => 404));
+
+        $this->assertEquals(
+            [
+                'custom_error' => 'message',
+                'custom_code'  => 404
             ],
             $exception->getResponseBody()
         );
@@ -77,5 +104,17 @@ class IDPExceptionTest extends \PHPUnit_Framework_TestCase
     {
         $exception = new IDPException(array('error' => '', 'message' => ''));
         $this->assertEquals('Unknown Error.', $exception->getMessage());
+    }
+
+    public function testGetMessageCustom()
+    {
+        $exception = new IDPException(array('custom_error' => 'error_message', 'custom_code' => 404), 'error_message', 404);
+        $this->assertEquals('error_message', $exception->getMessage());
+    }
+
+    public function testGetCodeCustom()
+    {
+        $exception = new IDPException(array('custom_error' => 'error_message', 'custom_code' => 404), 'error_message', 404);
+        $this->assertEquals(404, $exception->getCode());
     }
 }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -215,11 +215,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
-
-    public function testSetErrorChecker()
-    {
-
-    }
 }
 
 class MockProvider extends \League\OAuth2\Client\Provider\AbstractProvider


### PR DESCRIPTION
add a errorChecker property in provider, so we can handle custom error.
When I wrote a third party provider, i found it return '{"errcode": xxxx, "errmsg": "invalid token"}' when encountering error. It is hard for oauth2-client 1.0 to handle this error type.