### PR TITLE
Add feature for provider to parse error response before throwing IDPException

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -223,7 +223,7 @@ abstract class AbstractProvider implements ProviderInterface
 
         if (isset($result['error']) && ! empty($result['error'])) {
             // @codeCoverageIgnoreStart
-            throw new IDPException($result);
+            $this->throwIDPException($result);
             // @codeCoverageIgnoreEnd
         }
 
@@ -304,6 +304,18 @@ abstract class AbstractProvider implements ProviderInterface
     public function userScreenName($response, AccessToken $token)
     {
         return isset($response->name) && $response->name ? $response->name : null;
+    }
+
+    /**
+     * Throws an IDPException when an error response is received
+     *
+     * @param array $result
+     *
+     * @throws IDPException
+     */
+    public function throwIDPException(array $result)
+    {
+        throw new IDPException($result);
     }
 
     /**


### PR DESCRIPTION
Facebook error responses are returned like so:

    {"error":{"message":"Some auth error","type":"OAuthException","code":191}}

So when there is an error and it gets to the `IDPException` constructor, it will try to send an array to the `$exception` argument of `parent::__construct()` which throws the following error:

    Fatal error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]]) in %s on line %d

This PR adds a new `throwIDPException()` method to the `AbstractProvider` so that a provider can parse the error response before the `IDPException` is thrown.

In the Facebook provider case it would look like this:

```php
class FacebookProvider extends AbstractProvider
{
    public function throwIDPException(array $result)
    {
        $result = $result['error'];

        throw new IDPException($result);
    }
}
```