### PR TITLE
Add new getResponseErrorMessage method

### DIFF
--- a/src/Exception/IDPException.php
+++ b/src/Exception/IDPException.php
@@ -8,6 +8,11 @@ class IDPException extends \Exception
 
     public function __construct($result)
     {
+        if (!empty($result['error']) && is_array($result['error'])) {
+            // Error response is wrapped in a top entity type, JSON:API style.
+            $result = $result['error'];
+        }
+
         $this->result = $result;
 
         $code = isset($result['code']) ? $result['code'] : 0;

--- a/test/src/Exception/IDPExceptionTest.php
+++ b/test/src/Exception/IDPExceptionTest.php
@@ -42,6 +42,13 @@ class IDPExceptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('message: 404: message', (string)$exception);
     }
 
+    public function testAsWrapped()
+    {
+        $exception = new IDPException(array('error' => array('error' => 'message')));
+
+        $this->assertEquals('message: message', (string)$exception);
+    }
+
     public function testGetResponseBody()
     {
         $exception = new IDPException(array('error' => 'message', 'code' => 404));


### PR DESCRIPTION
- add `prepareResponse` method to parse responses
- use `prepareResponse` within `fetchProviderData`
- handle wrapped errors in `IDPException`