### PR TITLE
Add consistent response handling

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -202,9 +202,7 @@ abstract class AbstractProvider implements ProviderInterface
                 // @codeCoverageIgnoreEnd
             }
         } catch (HttpAdapterException $e) {
-            // @codeCoverageIgnoreStart
             $response = (string) $e->getResponse()->getBody();
-            // @codeCoverageIgnoreEnd
         }
 
         $result = $this->parseResponse($response);

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -281,43 +281,49 @@ abstract class AbstractProvider implements ProviderInterface
     {
         $response = $this->fetchUserDetails($token);
 
-        return $this->userDetails(json_decode($response), $token);
+        return $this->userDetails($response, $token);
     }
 
     public function getUserUid(AccessToken $token)
     {
         $response = $this->fetchUserDetails($token, true);
 
-        return $this->userUid(json_decode($response), $token);
+        return $this->userUid($response, $token);
     }
 
     public function getUserEmail(AccessToken $token)
     {
         $response = $this->fetchUserDetails($token, true);
 
-        return $this->userEmail(json_decode($response), $token);
+        return $this->userEmail($response, $token);
     }
 
     public function getUserScreenName(AccessToken $token)
     {
         $response = $this->fetchUserDetails($token, true);
 
-        return $this->userScreenName(json_decode($response), $token);
+        return $this->userScreenName($response, $token);
     }
 
     public function userUid($response, AccessToken $token)
     {
-        return isset($response->id) && $response->id ? $response->id : null;
+        if (!empty($response['id'])) {
+            return $response['id'];
+        }
     }
 
     public function userEmail($response, AccessToken $token)
     {
-        return isset($response->email) && $response->email ? $response->email : null;
+        if (!empty($response['email'])) {
+            return $response['email'];
+        }
     }
 
     public function userScreenName($response, AccessToken $token)
     {
-        return isset($response->name) && $response->name ? $response->name : null;
+        if (!empty($response['name'])) {
+            return $response['name'];
+        }
     }
 
     /**

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -9,6 +9,7 @@ use Ivory\HttpAdapter\HttpAdapterInterface;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Grant\GrantInterface;
 use League\OAuth2\Client\Token\AccessToken as AccessToken;
+use UnexpectedValueException;
 
 abstract class AbstractProvider implements ProviderInterface
 {
@@ -230,10 +231,10 @@ abstract class AbstractProvider implements ProviderInterface
 
         switch ($this->responseType) {
             case 'json':
-                $json = json_decode($response, true);
+                $result = json_decode($response, true);
 
-                if (JSON_ERROR_NONE === json_last_error()) {
-                    $result = $json;
+                if (JSON_ERROR_NONE !== json_last_error()) {
+                    throw new UnexpectedValueException('Unable to parse client response');
                 }
 
                 break;

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -137,22 +137,24 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
     public function userPropertyProvider()
     {
-        $response = new \stdClass();
-        $response->id = 1;
-        $response->email = 'test@example.com';
-        $response->name = 'test';
+        $response = [
+            'id'    => 1,
+            'email' => 'test@example.com',
+            'name'  => 'test',
+        ];
 
-        $response2 = new \stdClass();
-        $response2->id = null;
-        $response2->email = null;
-        $response2->name = null;
+        $response2 = [
+            'id'    => null,
+            'email' => null,
+            'name'  => null,
+        ];
 
-        $response3 = new \stdClass();
+        $response3 = [];
 
         return [
-            [$response, 'test', 'test@example.com', 1],
-            [$response2],
-            [$response3],
+            'full response'  => [$response, 'test', 'test@example.com', 1],
+            'empty response' => [$response2],
+            'no response'    => [$response3],
         ];
     }
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -214,6 +214,29 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Foo error', $errorMessage);
         $this->assertEquals(1337, $errorCode);
     }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     */
+    public function testParseResponseJsonFailure()
+    {
+        $provider = new MockProvider([
+          'clientId' => 'mock_client_id',
+          'clientSecret' => 'mock_secret',
+          'redirectUri' => 'none',
+        ]);
+
+        $response = m::mock('Ivory\HttpAdapter\Message\ResponseInterface');
+        $response->shouldReceive('getBody')
+                 ->times(1)
+                 ->andReturn('not json');
+
+        $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
+        $client->shouldReceive('post')->times(1)->andReturn($response);
+        $provider->setHttpClient($client);
+
+        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
 }
 
 class MockProvider extends \League\OAuth2\Client\Provider\AbstractProvider


### PR DESCRIPTION
- add `parseResponse` method
- use `parseResponse` with `getAccessToken`
- use `parseResponse` with `fetchProviderData`
- success and error response handling use the same path
- update `getUserFoo` methods accordingly