### PR TITLE
Modify how provider response errors are handled

### DIFF
--- a/src/Provider/Exception/IdentityProviderException.php
+++ b/src/Provider/Exception/IdentityProviderException.php
@@ -4,40 +4,20 @@ namespace League\OAuth2\Client\Provider\Exception;
 
 class IdentityProviderException extends \Exception
 {
-    protected $result;
+    /**
+     * @var mixed
+     */
+    protected $response;
 
-    public function __construct($message, $code, $result)
+    public function __construct($message, $code, $response)
     {
-        $this->result = $result;
+        $this->response = $response;
 
         parent::__construct($message, $code);
     }
 
     public function getResponseBody()
     {
-        return $this->result;
-    }
-
-    public function getType()
-    {
-        $result = 'Exception';
-
-        return $result;
-    }
-
-    /**
-     * To make debugging easier.
-     *
-     * @return string The string representation of the error.
-     */
-    public function __toString()
-    {
-        $str = $this->getType().': ';
-
-        if ($this->code != 0) {
-            $str .= $this->code.': ';
-        }
-
-        return $str.$this->message;
+        return $this->response;
     }
 }

--- a/src/Provider/ProviderInterface.php
+++ b/src/Provider/ProviderInterface.php
@@ -100,15 +100,6 @@ interface ProviderInterface
     public function getHeaders($token = null);
 
     /**
-     * Throws an IdentityProviderException when an error response is received
-     *
-     * @throws IdentityProviderException
-     * @param array $result
-     * @return void
-     */
-    public function errorCheck(array $result);
-
-    /**
      * Get the authorized user details from the provider.
      *
      * Details are specific to the individual provider and may not be consistent!

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -28,10 +28,10 @@ class Fake extends AbstractProvider
         return new Fake\User;
     }
 
-    public function errorCheck(array $result)
+    protected function checkResponse(array $response)
     {
-        if (isset($result['error']) && !empty($result['error'])) {
-            throw new IdentityProviderException($result['error'], $result['code'], $result);
+        if (!empty($response['error'])) {
+            throw new IdentityProviderException($response['error'], $response['code'], $response);
         }
     }
 }


### PR DESCRIPTION
- change `public checkError` into `protected checkResponse`
- remove custom `toString` handling in `IdentityProviderException`
- clean up tests