### PR TITLE
Fix regex test for CSRPNG

### DIFF
--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -216,7 +216,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         parse_str(parse_url($url, PHP_URL_QUERY), $qs);
 
-        $this->assertRegExp('/[a-zA-Z0-9\/+]{32}\b/', $qs['state']);
+        $this->assertRegExp('/^[a-zA-Z0-9\/+]{32}$/', $qs['state']);
     }
 
     public function testErrorResponsesCanBeCustomizedAtTheProvider()


### PR DESCRIPTION
Test string `5BK0n+pM7o35bEyc8p4WFusi147N/JV/` was failing because of the `\b`.

Refs #212, #277