### PR TITLE
Remove extra user methods from abstract provider

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -407,11 +407,20 @@ abstract class AbstractProvider implements ProviderInterface
         }
     }
 
+    /**
+     * Generate a user object from a successful user details request.
+     *
+     * @param object $response
+     * @param AccessToken $token
+     * @return League\OAuth2\Client\Provider\UserInterface
+     */
+    abstract protected function prepareUserDetails(array $response, AccessToken $token);
+
     public function getUserDetails(AccessToken $token)
     {
         $response = $this->fetchUserDetails($token);
 
-        return $this->userDetails($response, $token);
+        return $this->prepareUserDetails($response, $token);
     }
 
     public function getUserUid(AccessToken $token)
@@ -439,20 +448,6 @@ abstract class AbstractProvider implements ProviderInterface
     {
         if (!empty($response['id'])) {
             return $response['id'];
-        }
-    }
-
-    public function userEmail($response, AccessToken $token)
-    {
-        if (!empty($response['email'])) {
-            return $response['email'];
-        }
-    }
-
-    public function userScreenName($response, AccessToken $token)
-    {
-        if (!empty($response['name'])) {
-            return $response['name'];
         }
     }
 
@@ -485,7 +480,7 @@ abstract class AbstractProvider implements ProviderInterface
     {
         $url = $this->urlUserDetails($token);
 
-        $request = $this->getAuthenticatedRequest(Request::METHOD_GET, $url, $token);
+        $request = $this->getAuthenticatedRequest(RequestInterface::METHOD_GET, $url, $token);
 
         return $this->getResponse($request);
     }

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -162,7 +162,6 @@ abstract class AbstractProvider implements ProviderInterface
     abstract public function urlAuthorize();
     abstract public function urlAccessToken();
     abstract public function urlUserDetails(AccessToken $token);
-    abstract public function userDetails($response, AccessToken $token);
     // End of methods to delete.
 
     public function getScopes()

--- a/src/Provider/ProviderInterface.php
+++ b/src/Provider/ProviderInterface.php
@@ -33,16 +33,6 @@ interface ProviderInterface
     public function urlUserDetails(AccessToken $token);
 
     /**
-     * Given an object response from the server, process the user details into a
-     * format expected by the user of the client.
-     *
-     * @param object $response
-     * @param AccessToken $token
-     * @return mixed
-     */
-    public function userDetails($response, AccessToken $token);
-
-    /**
      * Get the configured scopes for this provider.
      *
      * @return array
@@ -108,28 +98,4 @@ interface ProviderInterface
      * @return League\OAuth2\Client\Provider\UserInterface
      */
     public function getUserDetails(AccessToken $token);
-
-    /**
-     * Get the authorized user id from the provider.
-     *
-     * @param AccessToken $token
-     * @return mixed
-     */
-    public function getUserUid(AccessToken $token);
-
-    /**
-     * Get the authorized user email from the provider.
-     *
-     * @param AccessToken $token
-     * @return mixed
-     */
-    public function getUserEmail(AccessToken $token);
-
-    /**
-     * Get the authorized user screen name from the provider.
-     *
-     * @param AccessToken $token
-     * @return mixed
-     */
-    public function getUserScreenName(AccessToken $token);
 }

--- a/src/Provider/UserInterface.php
+++ b/src/Provider/UserInterface.php
@@ -4,5 +4,10 @@ namespace League\OAuth2\Client\Provider;
 
 interface UserInterface
 {
+    /**
+     * Get the identifier of the authorized user.
+     *
+     * @return mixed
+     */
     public function getUserId();
 }

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -23,9 +23,9 @@ class Fake extends AbstractProvider
         return 'http://example.com/oauth/user';
     }
 
-    public function userDetails($response, AccessToken $token)
+    protected function prepareUserDetails(array $response, AccessToken $token)
     {
-        return new Fake\User;
+        return new Fake\User($response);
     }
 
     protected function checkResponse(array $response)

--- a/test/src/Provider/Fake/User.php
+++ b/test/src/Provider/Fake/User.php
@@ -6,8 +6,28 @@ use League\OAuth2\Client\Provider\UserInterface;
 
 class User implements UserInterface
 {
+    /**
+     * @var array
+     */
+    protected $response;
+
+    public function __construct(array $response)
+    {
+        $this->response = $response;
+    }
+
     public function getUserId()
     {
-        return 123;
+        return $this->response['id'];
+    }
+
+    public function getUserEmail()
+    {
+        return $this->response['email'];
+    }
+
+    public function getUserScreenName()
+    {
+        return $this->response['name'];
     }
 }


### PR DESCRIPTION
- documented `UserInterface`
- remove methods for user data fetching
- modify internals for creating `User` objects in providers
- update tests

Refs #267 and discussions on #274.