### PR TITLE
Allow "scope" to be overloaded in the authorize URL

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -204,15 +204,18 @@ abstract class AbstractProvider implements ProviderInterface
             // non-trivial amount of time to run.
             'response_type'   => 'code',
             'approval_prompt' => 'auto',
+            'scope'           => $this->scopes,
         ];
 
-        $scopes = is_array($this->scopes) ? implode($this->scopeSeparator, $this->scopes) : $this->scopes;
+        if (is_array($options['scope'])) {
+            $options['scope'] = implode($this->scopeSeparator, $options['scope']);
+        }
 
         $params = [
             'client_id'       => $this->clientId,
             'redirect_uri'    => $this->redirectUri,
             'state'           => $this->state,
-            'scope'           => $scopes,
+            'scope'           => $options['scope'],
             'response_type'   => $options['response_type'],
             'approval_prompt' => $options['approval_prompt'],
         ];

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -192,6 +192,16 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['Authorization' => 'Bearer xyz'], $provider->getHeaders($token));
     }
 
+    public function testScopesOverloadedDuringAuthorize()
+    {
+        $url = $this->provider->getAuthorizationUrl(['scope' => ['foo', 'bar']]);
+
+        parse_str(parse_url($url, PHP_URL_QUERY), $qs);
+
+        $this->assertArrayHasKey('scope', $qs);
+        $this->assertSame('foo,bar', $qs['scope']);
+    }
+
     public function testRandomGeneratorCreatesRandomState()
     {
         $xstate = str_repeat('x', 32);


### PR DESCRIPTION
- enable `scope` to be overloaded by runtime options
- update tests