### PR TITLE
Convert the grant factory to use singletons

### DIFF
--- a/src/Grant/GrantFactory.php
+++ b/src/Grant/GrantFactory.php
@@ -10,52 +10,51 @@ class GrantFactory
     protected $registry = [];
 
     /**
-     * Define a grant class in the registry.
+     * Define a grant singleton in the registry.
      *
      * @param  string $name
-     * @param  string $class
+     * @param  GrantInterface $class
      * @return $this
      */
-    public function setGrant($name, $class)
+    public function setGrant($name, GrantInterface $grant)
     {
-        $this->registry[$name] = $this->checkGrant($class);
+        $this->registry[$name] = $grant;
 
         return $this;
     }
 
     /**
-     * Get a grant instance by name.
+     * Get a grant singleton by name.
      *
      * If the grant has not be registered, a default grant will be loaded.
      *
      * @param  string $name
-     * @param  string $options
      * @return GrantInterface
      */
-    public function getGrant($name, array $options = [])
+    public function getGrant($name)
     {
         if (empty($this->registry[$name])) {
-            $this->registry[$name] = $this->getGrantClass($name);
+            $this->registerDefaultGrant($name);
         }
 
-        $class = $this->registry[$name];
-
-        return new $class($options);
+        return $this->registry[$name];
     }
 
     /**
-     * Guess a grant class from the name of the grant.
+     * Register a default grant singleton by name.
      *
      * @param  string $name
-     * @return string
+     * @return $this
      */
-    protected function getGrantClass($name)
+    protected function registerDefaultGrant($name)
     {
         // PascalCase the grant. E.g: 'authorization_code' becomes 'AuthorizationCode'
         $class = str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $name)));
         $class = 'League\\OAuth2\\Client\\Grant\\' . $class;
 
-        return $this->checkGrant($class);
+        $this->checkGrant($class);
+
+        return $this->setGrant($name, new $class);
     }
 
     /**
@@ -72,9 +71,9 @@ class GrantFactory
     /**
      * Check if a variable is a valid grant.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidGrantException
      * @param  mixed $class
-     * @return mixed
+     * @return void
      */
     public function checkGrant($class)
     {
@@ -84,6 +83,5 @@ class GrantFactory
                 is_object($class) ? get_class($class) : $class
             ));
         }
-        return $class;
     }
 }

--- a/test/src/Grant/Fake.php
+++ b/test/src/Grant/Fake.php
@@ -12,12 +12,12 @@ class Fake implements GrantInterface
         return 'fake';
     }
 
-    public function prepRequestParams($defaultParams, $params)
+    public function prepRequestParams(array $defaultParams, array $params)
     {
         return array_merge($defaultParams, $params);
     }
 
-    public function handleResponse($response = array())
+    public function handleResponse(array $response = [])
     {
         return new AccessToken($response);
     }

--- a/test/src/Grant/GrantFactoryTest.php
+++ b/test/src/Grant/GrantFactoryTest.php
@@ -54,35 +54,26 @@ class GrantFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testSetGrantReplaceDefault()
     {
-        $class = 'League\OAuth2\Client\Test\Grant\Fake';
+        $mock = new MockGrant();
 
         $factory = new GrantFactory();
-        $factory->setGrant('password', $class);
+        $factory->setGrant('password', $mock);
 
         $grant = $factory->getGrant('password');
 
-        $this->assertInstanceOf($class, $grant);
+        $this->assertSame($mock, $grant);
     }
 
     public function testSetGrantCustom()
     {
-        $class = 'League\OAuth2\Client\Test\Grant\Fake';
+        $mock = new MockGrant();
 
         $factory = new GrantFactory();
-        $factory->setGrant('fake', $class);
+        $factory->setGrant('fake', $mock);
 
         $grant = $factory->getGrant('fake');
 
-        $this->assertInstanceOf($class, $grant);
-
-    }
-
-    /**
-     * @expectedException League\OAuth2\Client\Grant\InvalidGrantException
-     */
-    public function testSetGrantInvalidFails()
-    {
-        $this->factory->setGrant('fail', 'stdClass');
+        $this->assertSame($mock, $grant);
     }
 
     public function testIsGrant()
@@ -96,7 +87,7 @@ class GrantFactoryTest extends \PHPUnit_Framework_TestCase
     public function testCheckGrant()
     {
         $grant = $this->factory->getGrant('password');
-        $this->assertSame($grant, $this->factory->checkGrant($grant));
+        $this->assertNull($this->factory->checkGrant($grant));
     }
 
     /**


### PR DESCRIPTION
Using class names is too much like dependency injection and should be left to DI containers. Grant singletons offer more flexibility for custom grant constructions and reduce the number of objects created during the lifecycle of auth flow.

Refs #284.