### PR TITLE
Use the correct parameters for HttpClient::get and post

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -283,18 +283,20 @@ abstract class AbstractProvider implements ProviderInterface
                 case 'GET':
                     // @codeCoverageIgnoreStart
                     // No providers included with this library use get but 3rd parties may
-                    $httpResponse = $client->get($this->urlAccessToken(), [
-                        'headers' => $this->getHeaders(),
-                        'query' => $requestParams,
-                    ]);
+                    $httpResponse = $client->get(
+                        $this->urlAccessToken(),
+                        $this->getHeaders(),
+                        $requestParams
+                    );
                     $response = (string) $httpResponse->getBody();
                     break;
                     // @codeCoverageIgnoreEnd
                 case 'POST':
-                    $httpResponse = $client->post($this->urlAccessToken(), [
-                        'headers' => $this->getHeaders(),
-                        'body' => $requestParams,
-                    ]);
+                    $httpResponse = $client->post(
+                        $this->urlAccessToken(),
+                        $this->getHeaders(),
+                        $requestParams
+                    );
                     $response = (string) $httpResponse->getBody();
                     break;
                 // @codeCoverageIgnoreStart

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -286,7 +286,13 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                  ->andReturn(json_encode($raw_response));
 
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
-        $client->shouldReceive('post')->times(1)->andReturn($response);
+        $client->shouldReceive('post')
+            ->with(
+                $provider->urlAccessToken(),
+                $headers = m::type('array'),
+                $params = m::type('array')
+            )
+            ->times(1)->andReturn($response);
 
         $provider->setHttpClient($client);
 
@@ -309,7 +315,13 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                  ->andReturn('{"error":"Foo error","code":1337}');
 
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
-        $client->shouldReceive('post')->times(1)->andReturn($response);
+        $client->shouldReceive('post')
+            ->with(
+                $provider->urlAccessToken(),
+                $headers = m::type('array'),
+                $params = m::type('array')
+            )
+            ->times(1)->andReturn($response);
         $provider->setHttpClient($client);
 
         $errorMessage = '';
@@ -346,7 +358,13 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $exception->setResponse($response);
 
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
-        $client->shouldReceive('post')->times(1)->andThrow($exception);
+        $client->shouldReceive('post')
+            ->with(
+                $provider->urlAccessToken(),
+                $headers = m::type('array'),
+                $params = m::type('array')
+            )
+            ->times(1)->andThrow($exception);
         $provider->setHttpClient($client);
 
         $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
@@ -369,7 +387,13 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                  ->andReturn('not json');
 
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
-        $client->shouldReceive('post')->times(1)->andReturn($response);
+        $client->shouldReceive('post')
+            ->with(
+                $provider->urlAccessToken(),
+                $headers = m::type('array'),
+                $params = m::type('array')
+            )
+            ->times(1)->andReturn($response);
         $provider->setHttpClient($client);
 
         $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);


### PR DESCRIPTION
Fixes #287.