### PR TITLE
Ensure that grant_type is the expected value

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -272,7 +272,7 @@ abstract class AbstractProvider implements ProviderInterface
             'client_id'     => $this->clientId,
             'client_secret' => $this->clientSecret,
             'redirect_uri'  => $this->redirectUri,
-            'grant_type'    => $grant,
+            'grant_type'    => (string) $grant,
         ];
 
         $requestParams = $grant->prepRequestParams($defaultParams, $params);


### PR DESCRIPTION
Force `Grant::__toString` to be executed when using the grant as a request parameter.

Fixes #288