### PR TITLE
Refactor internal configuration and public properties

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -16,12 +16,17 @@ use UnexpectedValueException;
 abstract class AbstractProvider implements ProviderInterface
 {
     /**
+     * @var string HTTP method used to fetch access tokens.
+     */
+    const ACCESS_TOKEN_METHOD = 'post';
+
+    /**
      * @var string Separator used for authorization scopes.
      */
     const SCOPE_SEPARATOR = ',';
 
     /**
-     * @var string Separator used for authorization scopes.
+     * @var string
      */
     protected $clientId = '';
 
@@ -49,11 +54,6 @@ abstract class AbstractProvider implements ProviderInterface
      * @var string
      */
     protected $uidKey = 'uid';
-
-    /**
-     * @var string
-     */
-    protected $method = 'post';
 
     /**
      * @var string
@@ -294,7 +294,7 @@ abstract class AbstractProvider implements ProviderInterface
 
         try {
             $client = $this->getHttpClient();
-            switch (strtoupper($this->method)) {
+            switch (strtoupper(static::ACCESS_TOKEN_METHOD)) {
                 case 'GET':
                     // @codeCoverageIgnoreStart
                     // No providers included with this library use get but 3rd parties may

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -18,62 +18,62 @@ abstract class AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    public $clientId = '';
+    protected $clientId = '';
 
     /**
      * @var string
      */
-    public $clientSecret = '';
+    protected $clientSecret = '';
 
     /**
      * @var string
      */
-    public $redirectUri = '';
+    protected $redirectUri = '';
 
     /**
      * @var string
      */
-    public $state;
+    protected $state;
 
     /**
      * @var string
      */
-    public $name;
+    protected $name;
 
     /**
      * @var string
      */
-    public $uidKey = 'uid';
+    protected $uidKey = 'uid';
 
     /**
      * @var array
      */
-    public $scopes = [];
+    protected $scopes = [];
 
     /**
      * @var string
      */
-    public $method = 'post';
+    protected $method = 'post';
 
     /**
      * @var string
      */
-    public $scopeSeparator = ',';
+    protected $scopeSeparator = ',';
 
     /**
      * @var string
      */
-    public $responseType = 'json';
+    protected $responseType = 'json';
 
     /**
      * @var array
      */
-    public $headers = [];
+    protected $headers = [];
 
     /**
      * @var string
      */
-    public $authorizationHeader;
+    protected $authorizationHeader;
 
     /**
      * @var GrantFactory
@@ -178,6 +178,18 @@ abstract class AbstractProvider implements ProviderInterface
     public function getRandomFactory()
     {
         return $this->randomFactory;
+    }
+
+    /**
+     * Get the current state of the OAuth flow.
+     *
+     * This can be accessed by the redirect handler during authorization.
+     *
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->state;
     }
 
     // Implementing these interfaces methods should not be required, but not

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -21,6 +21,11 @@ abstract class AbstractProvider implements ProviderInterface
     const ACCESS_TOKEN_METHOD = 'post';
 
     /**
+     * @var string Type of response expected from the provider.
+     */
+    const RESPONSE_TYPE = 'json';
+
+    /**
      * @var string Separator used for authorization scopes.
      */
     const SCOPE_SEPARATOR = ',';
@@ -54,11 +59,6 @@ abstract class AbstractProvider implements ProviderInterface
      * @var string
      */
     protected $uidKey = 'uid';
-
-    /**
-     * @var string
-     */
-    protected $responseType = 'json';
 
     /**
      * @var GrantFactory
@@ -387,7 +387,7 @@ abstract class AbstractProvider implements ProviderInterface
     {
         $result = [];
 
-        switch ($this->responseType) {
+        switch (static::RESPONSE_TYPE) {
             case 'json':
                 $result = json_decode($response, true);
                 if (JSON_ERROR_NONE !== json_last_error()) {

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -21,6 +21,11 @@ abstract class AbstractProvider implements ProviderInterface
     const ACCESS_TOKEN_METHOD = 'post';
 
     /**
+     * @var string Key used in the access token response to identify the user.
+     */
+    const ACCESS_TOKEN_UID = 'uid';
+
+    /**
      * @var string Type of response expected from the provider.
      */
     const RESPONSE_TYPE = 'json';
@@ -54,11 +59,6 @@ abstract class AbstractProvider implements ProviderInterface
      * @var string
      */
     protected $name;
-
-    /**
-     * @var string
-     */
-    protected $uidKey = 'uid';
 
     /**
      * @var GrantFactory
@@ -414,34 +414,18 @@ abstract class AbstractProvider implements ProviderInterface
     abstract protected function checkResponse(array $response);
 
     /**
-     * Prepare the access token response for the grant. Custom mapping of
-     * expirations, etc should be done here.
+     * Prepare the access token response for the grant.
+     *
+     * Custom mapping of expirations, etc should be done here. Always call the
+     * parent method when overloading this method!
      *
      * @param  array $result
      * @return array
      */
     protected function prepareAccessTokenResult(array $result)
     {
-        $this->setResultUid($result);
+        $result['uid'] = $result[static::ACCESS_TOKEN_UID];
         return $result;
-    }
-
-    /**
-     * Sets any result keys we've received matching our provider-defined uidKey to the key "uid".
-     *
-     * @param array $result
-     */
-    protected function setResultUid(array &$result)
-    {
-        // If we're operating with the default uidKey there's nothing to do.
-        if ($this->uidKey === "uid") {
-            return;
-        }
-
-        if (isset($result[$this->uidKey])) {
-            // The AccessToken expects a "uid" to have the key "uid".
-            $result['uid'] = $result[$this->uidKey];
-        }
     }
 
     /**

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -38,17 +38,17 @@ abstract class AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    protected $clientId = '';
+    protected $clientId;
 
     /**
      * @var string
      */
-    protected $clientSecret = '';
+    protected $clientSecret;
 
     /**
      * @var string
      */
-    protected $redirectUri = '';
+    protected $redirectUri;
 
     /**
      * @var string

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -66,16 +66,6 @@ abstract class AbstractProvider implements ProviderInterface
     protected $responseType = 'json';
 
     /**
-     * @var array
-     */
-    protected $headers = [];
-
-    /**
-     * @var string
-     */
-    protected $authorizationHeader;
-
-    /**
      * @var GrantFactory
      */
     protected $grantFactory;
@@ -491,18 +481,46 @@ abstract class AbstractProvider implements ProviderInterface
         return $this->getResponse($request);
     }
 
-    protected function getAuthorizationHeaders($token)
+    /**
+     * Get additional headers used by this provider.
+     *
+     * Typically this is used to set Accept or Content-Type headers.
+     *
+     * @param  AccessToken $token
+     * @return array
+     */
+    protected function getDefaultHeaders($token = null)
     {
-        $headers = [];
-        if ($this->authorizationHeader) {
-            $headers['Authorization'] = $this->authorizationHeader . ' ' . $token;
-        }
-        return $headers;
+        return [];
     }
 
+    /**
+     * Get authorization headers used by this provider.
+     *
+     * Typically this is "Bearer" or "MAC". For more information see:
+     * http://tools.ietf.org/html/rfc6749#section-7.1
+     *
+     * No default is provided, providers must overload this method to activate
+     * authorization headers.
+     *
+     * @return array
+     */
+    protected function getAuthorizationHeaders($token = null)
+    {
+        return [];
+    }
+
+    /**
+     * Get the headers used by this provider for a request.
+     *
+     * If a token is passed, the request may be authenticated through headers.
+     *
+     * @param  mixed $token  object or string
+     * @return array
+     */
     public function getHeaders($token = null)
     {
-        $headers = $this->headers;
+        $headers = $this->getDefaultHeaders();
         if ($token) {
             $headers = array_merge($headers, $this->getAuthorizationHeaders($token));
         }

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -119,6 +119,12 @@ abstract class AbstractProvider implements ProviderInterface
         $this->setRandomFactory($collaborators['randomFactory']);
     }
 
+    /**
+     * Set the grant factory instance.
+     *
+     * @param  GrantFactory $factory
+     * @return $this
+     */
     public function setGrantFactory(GrantFactory $factory)
     {
         $this->grantFactory = $factory;
@@ -126,13 +132,22 @@ abstract class AbstractProvider implements ProviderInterface
         return $this;
     }
 
+    /**
+     * Get the grant factory instance.
+     *
+     * @return GrantFactory
+     */
     public function getGrantFactory()
     {
-        $factory = $this->grantFactory;
-
-        return $factory;
+        return $this->grantFactory;
     }
 
+    /**
+     * Set the HTTP adapter instance.
+     *
+     * @param  HttpAdapterInterface $client
+     * @return $this
+     */
     public function setHttpClient(HttpAdapterInterface $client)
     {
         $this->httpClient = $client;
@@ -140,11 +155,14 @@ abstract class AbstractProvider implements ProviderInterface
         return $this;
     }
 
+    /**
+     * Get the HTTP adapter instance.
+     *
+     * @return HttpAdapterInterface
+     */
     public function getHttpClient()
     {
-        $client = $this->httpClient;
-
-        return $client;
+        return $this->httpClient;
     }
 
     /**

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -71,11 +71,6 @@ abstract class AbstractProvider implements ProviderInterface
     protected $randomFactory;
 
     /**
-     * @var Closure
-     */
-    protected $redirectHandler;
-
-    /**
      * @var int This represents: PHP_QUERY_RFC1738, which is the default value for php 5.4
      *          and the default encryption type for the http_build_query setup
      */
@@ -256,13 +251,11 @@ abstract class AbstractProvider implements ProviderInterface
         return $this->urlAuthorize().'?'.$this->httpBuildQuery($params, '', '&');
     }
 
-    // @codeCoverageIgnoreStart
-    public function authorize(array $options = [])
+    public function authorize(array $options = [], $redirectHandler = null)
     {
         $url = $this->getAuthorizationUrl($options);
-        if ($this->redirectHandler) {
-            $handler = $this->redirectHandler;
-            return $handler($url, $this);
+        if ($redirectHandler) {
+            return $redirectHandler($url, $this);
         }
         // @codeCoverageIgnoreStart
         header('Location: ' . $url);
@@ -517,10 +510,5 @@ abstract class AbstractProvider implements ProviderInterface
             $headers = array_merge($headers, $this->getAuthorizationHeaders($token));
         }
         return $headers;
-    }
-
-    public function setRedirectHandler(Closure $handler)
-    {
-        $this->redirectHandler = $handler;
     }
 }

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -56,11 +56,6 @@ abstract class AbstractProvider implements ProviderInterface
     protected $state;
 
     /**
-     * @var string
-     */
-    protected $name;
-
-    /**
      * @var GrantFactory
      */
     protected $grantFactory;

--- a/src/Provider/ProviderInterface.php
+++ b/src/Provider/ProviderInterface.php
@@ -33,21 +33,6 @@ interface ProviderInterface
     public function urlUserDetails(AccessToken $token);
 
     /**
-     * Get the configured scopes for this provider.
-     *
-     * @return array
-     */
-    public function getScopes();
-
-    /**
-     * Configure the scopes that will be requested by this provider.
-     *
-     * @param array $scopes
-     * @return void
-     */
-    public function setScopes(array $scopes);
-
-    /**
      * Get the URL that this provider uses to request authorization.
      *
      * Additional options such as the OAuth state and response type can be set here.

--- a/src/Tool/BearerAuthorizationTrait.php
+++ b/src/Tool/BearerAuthorizationTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace League\OAuth2\Client\Tool;
+
+/**
+ * Enables `Bearer` header authorization for providers.
+ *
+ * http://tools.ietf.org/html/rfc6750
+ */
+trait BearerAuthorizationTrait
+{
+    protected function getAuthorizationHeaders($token = null)
+    {
+        return ['Authorization' => 'Bearer ' . $token];
+    }
+}

--- a/src/Tool/MacAuthorizationTrait.php
+++ b/src/Tool/MacAuthorizationTrait.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace League\OAuth2\Client\Tool;
+
+use League\OAuth2\Client\Token\AccessToken;
+
+/**
+ * Enables `MAC` header authorization for providers.
+ *
+ * http://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-05
+ */
+trait MacAuthorizationTrait
+{
+    /**
+     * Get the id of this token for MAC generation.
+     *
+     * @param  AccessToken $token
+     * @return string
+     */
+    abstract protected function getTokenId(AccessToken $token);
+
+    /**
+     * Get the MAC signature for the current request.
+     *
+     * @param  string $id
+     * @param  integer $ts
+     * @param  string $nonce
+     * @return string
+     */
+    abstract protected function getMacSignature($id, $ts, $nonce);
+
+    // AbstractProvider
+    abstract protected function getRandomState($length);
+
+    protected function getAuthorizationHeaders($token = null)
+    {
+        // This is currently untested and provided only as an example. If you
+        // complete the implementation, please create a pull request for
+        // https://github.com/thephpleague/oauth2-client
+
+        // @codeCoverageIgnoreStart
+        $ts    = time();
+        $id    = $this->getTokenId($token);
+        $nonce = $this->getRandomState(16);
+        $mac   = $this->getMacSignature($id, $ts, $nonce);
+
+        $parts = [];
+        foreach (compact('id', 'ts', 'nonce', 'mac') as $key => $value) {
+            $parts[] = sprintf('%s="%s"', $key, $value);
+        }
+
+        return ['Authorization' => 'MAC ' . implode(",\n", $parts)];
+        // @codeCoverageIgnoreEnd
+    }
+}

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -66,7 +66,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'redirectUri' => 'http://example.org/redirect',
             'state' => 'foo',
             'name' => 'bar',
-            'uidKey' => 'mynewuid',
         ];
 
         $mockProvider = new MockProvider($options);
@@ -260,7 +259,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $grant_name = 'mock';
-        $raw_response = ['access_token' => 'okay', 'expires_in' => 3600];
+        $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'uid' => 3];
         $token = new AccessToken($raw_response);
 
         $contains_correct_grant_type = function ($params) use ($grant_name) {
@@ -300,6 +299,9 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $result = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code']);
 
         $this->assertSame($result, $token);
+        $this->assertSame($raw_response['uid'], $token->uid);
+        $this->assertSame($raw_response['access_token'], $token->accessToken);
+        $this->assertSame($raw_response['expires'], $token->expires);
     }
 
     public function testErrorResponsesCanBeCustomizedAtTheProvider()

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -67,9 +67,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'state' => 'foo',
             'name' => 'bar',
             'uidKey' => 'mynewuid',
-            'scopes' => ['a', 'b', 'c'],
             'method' => 'get',
-            'scopeSeparator' => ';',
             'responseType' => 'csv',
         ];
 
@@ -213,6 +211,13 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testScopesOverloadedDuringAuthorize()
     {
+        $url = $this->provider->getAuthorizationUrl();
+
+        parse_str(parse_url($url, PHP_URL_QUERY), $qs);
+
+        $this->assertArrayHasKey('scope', $qs);
+        $this->assertSame('test', $qs['scope']);
+
         $url = $this->provider->getAuthorizationUrl(['scope' => ['foo', 'bar']]);
 
         parse_str(parse_url($url, PHP_URL_QUERY), $qs);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -71,8 +71,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'method' => 'get',
             'scopeSeparator' => ';',
             'responseType' => 'csv',
-            'headers' => ['Foo' => 'Bar'],
-            'authorizationHeader' => 'Bearer',
         ];
 
         $mockProvider = new MockProvider($options);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -67,7 +67,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'state' => 'foo',
             'name' => 'bar',
             'uidKey' => 'mynewuid',
-            'responseType' => 'csv',
         ];
 
         $mockProvider = new MockProvider($options);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -78,7 +78,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $mockProvider = new MockProvider($options);
 
         foreach ($options as $key => $value) {
-            $this->assertEquals($value, $mockProvider->{$key});
+            $this->assertAttributeEquals($value, $key, $mockProvider);
         }
     }
 
@@ -113,7 +113,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $callback = function ($url, $provider) {
             $this->testFunction = $url;
-            $this->state = $provider->state;
+            $this->state = $provider->getState();
         };
 
         $this->provider->setRedirectHandler($callback);
@@ -121,7 +121,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->provider->authorize();
 
         $this->assertNotFalse($this->testFunction);
-        $this->assertEquals($this->provider->state, $this->state);
+        $this->assertAttributeEquals($this->state, 'state', $this->provider);
     }
 
     /**
@@ -403,8 +403,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     {
         $token = new AccessToken(['access_token' => 'abc', 'expires_in' => 3600]);
 
-        $provider = clone $this->provider;
-        $provider->authorizationHeader = 'Bearer';
+        $provider = new MockProvider(['authorizationHeader' => 'Bearer']);
 
         $request = $provider->getAuthenticatedRequest('get', 'https://api.example.com/v1/test', $token);
         $this->assertInstanceOf('Ivory\HttpAdapter\Message\RequestInterface', $request);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -65,7 +65,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'clientSecret' => '4567',
             'redirectUri' => 'http://example.org/redirect',
             'state' => 'foo',
-            'name' => 'bar',
         ];
 
         $mockProvider = new MockProvider($options);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -67,7 +67,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'state' => 'foo',
             'name' => 'bar',
             'uidKey' => 'mynewuid',
-            'method' => 'get',
             'responseType' => 'csv',
         ];
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -108,9 +108,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             $this->state = $provider->getState();
         };
 
-        $this->provider->setRedirectHandler($callback);
-
-        $this->provider->authorize();
+        $this->provider->authorize([], $callback);
 
         $this->assertNotFalse($this->testFunction);
         $this->assertAttributeEquals($this->state, 'state', $this->provider);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -64,7 +64,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'clientId' => '1234',
             'clientSecret' => '4567',
             'redirectUri' => 'http://example.org/redirect',
-            'state' => 'foo',
+            'httpBuildEncType' => 4,
         ];
 
         $mockProvider = new MockProvider($options);

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -26,6 +26,11 @@ class Fake extends AbstractProvider
         return 'http://example.com/oauth/user';
     }
 
+    protected function getDefaultScopes()
+    {
+        return ['test'];
+    }
+
     protected function prepareUserDetails(array $response, AccessToken $token)
     {
         return new Fake\User($response);

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -3,11 +3,14 @@
 namespace League\OAuth2\Client\Test\Provider;
 
 use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 
 class Fake extends AbstractProvider
 {
+    use BearerAuthorizationTrait;
+
     public function urlAuthorize()
     {
         return 'http://example.com/oauth/authorize';


### PR DESCRIPTION
- all properties in `AbstractProvider` made protected
- many config properties removed in favor of protected methods that can be overloaded
- modified header, scope, redirects, etc handling
- tests updated