### PR TITLE
Minor documentation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ if (!isset($_GET['code'])) {
     // Use this to get a new access token if the old one expires
     echo $token->refreshToken;
 
-    // Number of seconds until the access token will expire, and need refreshing
+    // Unix timestamp of when the token will expire, and need refreshing
     echo $token->expires;
 }
 ```


### PR DESCRIPTION
The `README.md` file states that the `expires` property of an `AccessToken` instance is the number of seconds until it expires, when in actual fact it is the timestamp of the expiry. This gave me some weird errors when I read it this way so I thought I would update the docs. 

You can see this in the [source](https://github.com/thephpleague/oauth2-client/blob/master/src/Token/AccessToken.php#L64) where an attempt is made to make this a timestamp unconditionally.