### PR TITLE
Ignore exceptions that have no response attached

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -313,6 +313,9 @@ abstract class AbstractProvider implements ProviderInterface
                 // @codeCoverageIgnoreEnd
             }
         } catch (HttpAdapterException $e) {
+            if (!$e->hasResponse()) {
+                throw $e;
+            }
             $response = (string) $e->getResponse()->getBody();
         }
 
@@ -361,6 +364,9 @@ abstract class AbstractProvider implements ProviderInterface
 
             $response = (string) $httpResponse->getBody();
         } catch (HttpAdapterException $e) {
+            if (!$e->hasResponse()) {
+                throw $e;
+            }
             $response = (string) $e->getResponse()->getBody();
         }
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -339,6 +339,27 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \Ivory\HttpAdapter\HttpAdapterException
+     */
+    public function testClientErrorWithoutResponseFailure()
+    {
+        $provider = new MockProvider();
+
+        $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
+        $client->shouldReceive('post')
+            ->with(
+                $provider->urlAccessToken(),
+                $headers = m::type('array'),
+                $params = m::type('array')
+            )
+            ->times(1)->andThrow(new HttpAdapterException);
+
+        $provider->setHttpClient($client);
+
+        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
+
+    /**
      * @expectedException \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      */
     public function testClientErrorTriggersProviderException()


### PR DESCRIPTION
When HTTP client fails and no response is available, allow the exception to bubble.

Fixes #304