### PR TITLE
Remove r_contactinfo.

### DIFF
--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -7,7 +7,7 @@ use League\OAuth2\Client\Token\AccessToken;
 
 class LinkedIn extends AbstractProvider
 {
-    public $scopes = ['r_basicprofile r_emailaddress r_contactinfo'];
+    public $scopes = ['r_basicprofile r_emailaddress' ];
     public $responseType = 'json';
     public $authorizationHeader = 'Bearer';
     public $fields = [


### PR DESCRIPTION
This is a fix because, it seems that linkedin now removes the r_contactinfo scope, so if the user add this scope, linked in says 'Your application has not been authorized for the scope "r_contactinfo"'