### PR TITLE
Switch to Guzzle 6 for HTTP client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ a patch via pull request.
 
 The following versions of PHP are supported.
 
-* PHP 5.4
 * PHP 5.5
 * PHP 5.6
 * PHP 7.0

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
     "require": {
         "php": ">=5.4.0",
         "ext-curl": "*",
-        "egeloen/http-adapter": "0.6.*",
-        "ircmaxell/random-lib": "~1.1"
+        "ircmaxell/random-lib": "~1.1",
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "OAuth 2.0 Client Library",
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "ext-curl": "*",
         "ircmaxell/random-lib": "~1.1",
         "guzzlehttp/guzzle": "~6.0"

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -3,13 +3,14 @@
 namespace League\OAuth2\Client\Provider;
 
 use Closure;
-use Ivory\HttpAdapter\CurlHttpAdapter;
-use Ivory\HttpAdapter\HttpAdapterException;
-use Ivory\HttpAdapter\HttpAdapterInterface;
-use Ivory\HttpAdapter\Message\RequestInterface;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\ClientInterface as HttpClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
+use Psr\Http\Message\RequestInterface;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Grant\GrantFactory;
 use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Tool\RequestFactory;
 use RandomLib\Factory as RandomFactory;
 use UnexpectedValueException;
 
@@ -28,7 +29,7 @@ abstract class AbstractProvider implements ProviderInterface
     /**
      * @var string HTTP method used to fetch access tokens.
      */
-    const ACCESS_TOKEN_METHOD = 'post';
+    const ACCESS_TOKEN_METHOD = 'POST';
 
     /**
      * @var string Key used in the access token response to identify the user.
@@ -66,6 +67,11 @@ abstract class AbstractProvider implements ProviderInterface
     protected $grantFactory;
 
     /**
+     * @var RequestFactory
+     */
+    protected $requestFactory;
+
+    /**
      * @var HttpAdapterInterface
      */
     protected $httpClient;
@@ -98,8 +104,16 @@ abstract class AbstractProvider implements ProviderInterface
         }
         $this->setGrantFactory($collaborators['grantFactory']);
 
+        if (empty($collaborators['requestFactory'])) {
+            $collaborators['requestFactory'] = new requestFactory();
+        }
+        $this->setRequestFactory($collaborators['requestFactory']);
+
         if (empty($collaborators['httpClient'])) {
-            $collaborators['httpClient'] = new CurlHttpAdapter();
+            $client_options = ['timeout'];
+            $collaborators['httpClient'] = new HttpClient(
+                array_intersect_key($options, array_flip($client_options))
+            );
         }
         $this->setHttpClient($collaborators['httpClient']);
 
@@ -107,12 +121,6 @@ abstract class AbstractProvider implements ProviderInterface
             $collaborators['randomFactory'] = new RandomFactory();
         }
         $this->setRandomFactory($collaborators['randomFactory']);
-
-        if (!empty($options['timeout'])) {
-            $this->getHttpClient()
-                ->getConfiguration()
-                ->setTimeout($options['timeout']);
-        }
     }
 
     /**
@@ -139,12 +147,35 @@ abstract class AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Set the HTTP adapter instance.
+     * Set the request factory instance.
      *
-     * @param  HttpAdapterInterface $client
+     * @param  RequestFactory $factory
      * @return $this
      */
-    public function setHttpClient(HttpAdapterInterface $client)
+    public function setRequestFactory(RequestFactory $factory)
+    {
+        $this->requestFactory = $factory;
+
+        return $this;
+    }
+
+    /**
+     * Get the request factory instance.
+     *
+     * @return RequestFactory
+     */
+    public function getRequestFactory()
+    {
+        return $this->requestFactory;
+    }
+
+    /**
+     * Set the HTTP adapter instance.
+     *
+     * @param  HttpClientInterface $client
+     * @return $this
+     */
+    public function setHttpClient(HttpClientInterface $client)
     {
         $this->httpClient = $client;
 
@@ -289,68 +320,63 @@ abstract class AbstractProvider implements ProviderInterface
             'grant_type'    => (string) $grant,
         ];
 
-        $requestParams = $grant->prepRequestParams($defaultParams, $params);
+        $requestParams  = $this->httpBuildQuery($grant->prepRequestParams($defaultParams, $params));
+        $urlAccessToken = $this->urlAccessToken();
 
-        try {
-            $client = $this->getHttpClient();
-            switch (strtoupper(static::ACCESS_TOKEN_METHOD)) {
-                case 'GET':
-                    // @codeCoverageIgnoreStart
-                    // No providers included with this library use get but 3rd parties may
-                    $httpResponse = $client->get(
-                        $this->urlAccessToken(),
-                        $this->getHeaders(),
-                        $requestParams
-                    );
-                    $response = (string) $httpResponse->getBody();
-                    break;
-                    // @codeCoverageIgnoreEnd
-                case 'POST':
-                    $httpResponse = $client->post(
-                        $this->urlAccessToken(),
-                        $this->getHeaders(),
-                        $requestParams
-                    );
-                    $response = (string) $httpResponse->getBody();
-                    break;
+        switch (strtoupper(static::ACCESS_TOKEN_METHOD)) {
+            case 'GET':
                 // @codeCoverageIgnoreStart
-                default:
-                    throw new \InvalidArgumentException('Neither GET nor POST is specified for request');
+                // No providers included with this library use get but 3rd parties may
+                $urlAccessToken .= (strpos($urlAccessToken, '?') ? '&' : '?') . $requestParams;
+                break;
                 // @codeCoverageIgnoreEnd
-            }
-        } catch (HttpAdapterException $e) {
-            if (!$e->hasResponse()) {
-                throw $e;
-            }
-            $response = (string) $e->getResponse()->getBody();
+            case 'POST':
+                $options['body'] = $requestParams;
+                break;
+            // @codeCoverageIgnoreStart
+            default:
+                throw new \InvalidArgumentException('Neither GET nor POST is specified for request');
+            // @codeCoverageIgnoreEnd
         }
 
-        $response = $this->parseResponse($response);
+        $request  = $this->getRequest(strtoupper(static::ACCESS_TOKEN_METHOD), $this->urlAccessToken(), $options);
+        $response = $this->getResponse($request);
         $response = $this->prepareAccessTokenResult($response);
 
         return $grant->handleResponse($response);
     }
 
     /**
+     * Get a request instance.
+     *
+     * Creates a PSR-7 compatible request instance that can be modified.
+     * The request is not automatically authenticated.
+     *
+     * @param  string $method
+     * @param  string $url
+     * @param  array  $options Any of "headers", "body", and "protocolVersion".
+     * @return RequestInterface
+     */
+    public function getRequest($method, $url, array $options = [])
+    {
+        return $this->getRequestFactory()->getRequestWithOptions($method, $url, $options);
+    }
+
+    /**
      * Get an authenticated request instance.
      *
      * Creates a PSR-7 compatible request instance that can be modified.
-     * Often used to create calls against an API that requires authentication.
      *
      * @param  string $method
      * @param  string $url
      * @param  AccessToken $token
+     * @param  array  $options Any of "headers", "body", and "protocolVersion".
      * @return RequestInterface
      */
-    public function getAuthenticatedRequest($method, $url, AccessToken $token)
+    public function getAuthenticatedRequest($method, $url, AccessToken $token, array $options = [])
     {
-        $factory = $this->getHttpClient()
-            ->getConfiguration()
-            ->getMessageFactory();
-
-        $request = $factory->createRequest($url, $method);
-        $request->addHeaders($this->getHeaders($token));
-        return $request;
+        $options['headers'] = $this->getHeaders($token);
+        return $this->getRequest($method, $url, $options);
     }
 
     /**
@@ -362,15 +388,11 @@ abstract class AbstractProvider implements ProviderInterface
     protected function sendRequest(RequestInterface $request)
     {
         try {
-            return $this->getHttpClient()->sendRequest($request);
-
-        } catch (HttpAdapterException $e) {
-            if ($e->hasResponse()) {
-                return $e->getResponse();
-            }
-
-            throw $e;
+            $response = $this->getHttpClient()->send($request);
+        } catch (BadResponseException $e) {
+            $response = $e->getResponse();
         }
+        return $response;
     }
 
     /**
@@ -384,7 +406,6 @@ abstract class AbstractProvider implements ProviderInterface
     public function getResponse(RequestInterface $request)
     {
         $response = (string) $this->sendRequest($request)->getBody();
-
         return $this->parseResponse($response);
     }
 
@@ -497,7 +518,7 @@ abstract class AbstractProvider implements ProviderInterface
     {
         $url = $this->urlUserDetails($token);
 
-        $request = $this->getAuthenticatedRequest(RequestInterface::METHOD_GET, $url, $token);
+        $request = $this->getAuthenticatedRequest('GET', $url, $token);
 
         return $this->getResponse($request);
     }

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -13,6 +13,7 @@ use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\RequestFactory;
 use RandomLib\Factory as RandomFactory;
 use UnexpectedValueException;
+use InvalidArgumentException;
 
 abstract class AbstractProvider implements ProviderInterface
 {
@@ -25,11 +26,6 @@ abstract class AbstractProvider implements ProviderInterface
      * @var string Parameter string response type.
      */
     const RESPONSE_TYPE_STRING = 'string';
-
-    /**
-     * @var string HTTP method used to fetch access tokens.
-     */
-    const ACCESS_TOKEN_METHOD = 'POST';
 
     /**
      * @var string Key used in the access token response to identify the user.
@@ -271,7 +267,7 @@ abstract class AbstractProvider implements ProviderInterface
 
         $options += [
             'response_type'   => 'code',
-            'approval_prompt' => 'auto',
+            'approval_prompt' => 'auto'
         ];
 
         if (is_array($options['scope'])) {
@@ -299,10 +295,21 @@ abstract class AbstractProvider implements ProviderInterface
         if ($redirectHandler) {
             return $redirectHandler($url, $this);
         }
+
         // @codeCoverageIgnoreStart
         header('Location: ' . $url);
         exit;
         // @codeCoverageIgnoreEnd
+    }
+
+    /**
+     * Returns the method to use when requesting an access token.
+     *
+     * @return string HTTP method
+     */
+    protected function getAccessTokenMethod()
+    {
+        return 'POST';
     }
 
     public function getAccessToken($grant = 'authorization_code', array $params = [])
@@ -320,26 +327,28 @@ abstract class AbstractProvider implements ProviderInterface
             'grant_type'    => (string) $grant,
         ];
 
-        $requestParams  = $this->httpBuildQuery($grant->prepRequestParams($defaultParams, $params));
-        $urlAccessToken = $this->urlAccessToken();
+        $requestParams = $grant->prepRequestParams($defaultParams, $params);
+        $requestParams = $this->httpBuildQuery($requestParams);
 
-        switch (strtoupper(static::ACCESS_TOKEN_METHOD)) {
+        $url = $this->urlAccessToken();
+        $method = strtoupper($this->getAccessTokenMethod());
+        $options = [];
+
+        switch ($method) {
             case 'GET':
-                // @codeCoverageIgnoreStart
                 // No providers included with this library use get but 3rd parties may
-                $urlAccessToken .= (strpos($urlAccessToken, '?') ? '&' : '?') . $requestParams;
+                $url .= (parse_url($url, PHP_URL_QUERY) ? '&' : '?') . $requestParams;
                 break;
-                // @codeCoverageIgnoreEnd
             case 'POST':
                 $options['body'] = $requestParams;
                 break;
-            // @codeCoverageIgnoreStart
             default:
-                throw new \InvalidArgumentException('Neither GET nor POST is specified for request');
-            // @codeCoverageIgnoreEnd
+                throw new InvalidArgumentException(
+                    "Unsupported access token request method: '$method'"
+                );
         }
 
-        $request  = $this->getRequest(strtoupper(static::ACCESS_TOKEN_METHOD), $this->urlAccessToken(), $options);
+        $request  = $this->getRequest($method, $url, $options);
         $response = $this->getResponse($request);
         $response = $this->prepareAccessTokenResult($response);
 

--- a/src/Tool/RequestFactory.php
+++ b/src/Tool/RequestFactory.php
@@ -4,15 +4,22 @@ namespace League\OAuth2\Client\Tool;
 
 use GuzzleHttp\Psr7\Request;
 
-// For history see https://github.com/guzzle/guzzle/pull/1101
+/**
+ * Used to produce PSR-7 Request instances.
+ *
+ * @see https://github.com/guzzle/guzzle/pull/1101
+ */
 class RequestFactory
 {
     /**
+     * Creates a PSR-7 Request instance.
+     *
      * @param  null|string $method HTTP method for the request.
      * @param  null|string $uri URI for the request.
-     * @param  array  $headers Headers for the message.
+     * @param  array $headers Headers for the message.
      * @param  string|resource|StreamInterface $body Message body.
-     * @param  string $protocolVersion HTTP protocol version.
+     * @param  string $version HTTP protocol version.
+     *
      * @return Request
      */
     public function getRequest(
@@ -20,36 +27,49 @@ class RequestFactory
         $uri,
         array $headers = [],
         $body = null,
-        $protocolVersion = '1.1'
+        $version = '1.1'
     ) {
-        return new Request($method, $uri, $headers, $body, $protocolVersion);
+        return new Request($method, $uri, $headers, $body, $version);
     }
 
     /**
-     * Get a request using a simplified array of options.
+     * Parses simplified options.
+     *
+     * @param array $options Simplified options.
+     *
+     * @return array Extended options for use with getRequest.
+     */
+    protected function parseOptions(array $options)
+    {
+        // Should match default values for getRequest
+        $defaults = [
+            'headers' => [],
+            'body'    => null,
+            'version' => '1.1',
+        ];
+
+        return array_merge($defaults, $options);
+    }
+
+    /**
+     * Creates a request using a simplified array of options.
      *
      * @param  null|string $method
      * @param  null|string $uri
      * @param  array $options
+     *
      * @return Request
      */
     public function getRequestWithOptions($method, $uri, array $options = [])
     {
-        $func    = new \ReflectionMethod($this, 'getRequest');
-        $params  = $func->getParameters();
-        $options = array_replace($options, compact('method', 'uri'));
-        $args    = [];
+        $options = $this->parseOptions($options);
 
-        foreach ($params as $param) {
-            $name = $param->getName();
-            if (isset($options[$name])) {
-                $value = $options[$name];
-            } else {
-                $value = $param->getDefaultValue();
-            }
-            $args[$name] = $value;
-        }
-
-        return $func->invokeArgs($this, array_values($args));
+        return $this->getRequest(
+            $method,
+            $uri,
+            $options['headers'],
+            $options['body'],
+            $options['version']
+        );
     }
 }

--- a/src/Tool/RequestFactory.php
+++ b/src/Tool/RequestFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace League\OAuth2\Client\Tool;
+
+use GuzzleHttp\Psr7\Request;
+
+// For history see https://github.com/guzzle/guzzle/pull/1101
+class RequestFactory
+{
+    /**
+     * @param  null|string $method HTTP method for the request.
+     * @param  null|string $uri URI for the request.
+     * @param  array  $headers Headers for the message.
+     * @param  string|resource|StreamInterface $body Message body.
+     * @param  string $protocolVersion HTTP protocol version.
+     * @return Request
+     */
+    public function getRequest(
+        $method,
+        $uri,
+        array $headers = [],
+        $body = null,
+        $protocolVersion = '1.1'
+    ) {
+        return new Request($method, $uri, $headers, $body, $protocolVersion);
+    }
+
+    /**
+     * Get a request using a simplified array of options.
+     *
+     * @param  null|string $method
+     * @param  null|string $uri
+     * @param  array $options
+     * @return Request
+     */
+    public function getRequestWithOptions($method, $uri, array $options = [])
+    {
+        $func    = new \ReflectionMethod($this, 'getRequest');
+        $params  = $func->getParameters();
+        $options = array_replace($options, compact('method', 'uri'));
+        $args    = [];
+
+        foreach ($params as $param) {
+            $name = $param->getName();
+            if (isset($options[$name])) {
+                $value = $options[$name];
+            } else {
+                $value = $param->getDefaultValue();
+            }
+            $args[$name] = $value;
+        }
+
+        return $func->invokeArgs($this, array_values($args));
+    }
+}

--- a/test/src/Grant/AuthorizationCodeTest.php
+++ b/test/src/Grant/AuthorizationCodeTest.php
@@ -13,12 +13,12 @@ class AuthorizationCodeTest extends GrantTestCase
         ];
     }
 
-    protected function getParamsExpectation()
+    protected function getParamExpectation()
     {
-        return function ($params) {
-            return !empty($params['grant_type'])
-                && $params['grant_type'] === 'authorization_code'
-                && !empty($params['code']);
+        return function ($body) {
+            return !empty($body['grant_type'])
+                && $body['grant_type'] === 'authorization_code'
+                && !empty($body['code']);
         };
     }
 

--- a/test/src/Grant/ClientCredentialsTest.php
+++ b/test/src/Grant/ClientCredentialsTest.php
@@ -13,11 +13,11 @@ class ClientCredentialsTest extends GrantTestCase
         ];
     }
 
-    protected function getParamsExpectation()
+    protected function getParamExpectation()
     {
-        return function ($params) {
-            return !empty($params['grant_type'])
-                && $params['grant_type'] === 'client_credentials';
+        return function ($body) {
+            return !empty($body['grant_type'])
+                && $body['grant_type'] === 'client_credentials';
         };
     }
 

--- a/test/src/Grant/GrantTestCase.php
+++ b/test/src/Grant/GrantTestCase.php
@@ -38,30 +38,33 @@ abstract class GrantTestCase extends \PHPUnit_Framework_TestCase
     abstract public function providerGetAccessToken();
 
     /**
-     * Callback to test access token request params.
+     * Callback to test access token request parameters.
      *
      * @return Closure
      */
-    abstract protected function getParamsExpectation();
+    abstract protected function getParamExpectation();
 
     /**
      * @dataProvider providerGetAccessToken
      */
     public function testGetAccessToken($grant, array $params = [])
     {
-        $stream = m::mock('Psr\Http\Message\StreamableInterface');
+        $stream = m::mock('Psr\Http\Message\StreamInterface');
         $stream->shouldReceive('__toString')->times(1)->andReturn(
             '{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}'
         );
 
-        $response = m::mock('Ivory\HttpAdapter\Message\ResponseInterface');
+        $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
 
-        $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
-        $client->shouldReceive('post')->with(
-            $this->provider->urlAccessToken(),
-            $this->provider->getHeaders(),
-            m::on($this->getParamsExpectation())
+        $paramCheck = $this->getParamExpectation();
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')->with(
+            $request = m::on(function ($request) use ($paramCheck) {
+                parse_str((string) $request->getBody(), $body);
+                return $paramCheck($body);
+            })
         )->times(1)->andReturn($response);
 
         $this->provider->setHttpClient($client);

--- a/test/src/Grant/PasswordTest.php
+++ b/test/src/Grant/PasswordTest.php
@@ -13,11 +13,13 @@ class PasswordTest extends GrantTestCase
         ];
     }
 
-    protected function getParamsExpectation()
+    protected function getParamExpectation()
     {
-        return function ($params) {
-            return !empty($params['username'])
-                && !empty($params['password']);
+        return function ($body) {
+            return !empty($body['grant_type'])
+                && $body['grant_type'] === 'password'
+                && !empty($body['username'])
+                && !empty($body['password']);
         };
     }
 

--- a/test/src/Grant/RefreshTokenTest.php
+++ b/test/src/Grant/RefreshTokenTest.php
@@ -13,11 +13,11 @@ class RefreshTokenTest extends GrantTestCase
         ];
     }
 
-    protected function getParamsExpectation()
+    protected function getParamExpectation()
     {
-        return function ($params) {
-            return !empty($params['grant_type'])
-                && $params['grant_type'] === 'refresh_token';
+        return function ($body) {
+            return !empty($body['grant_type'])
+                && $body['grant_type'] === 'refresh_token';
         };
     }
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace League\OAuth2\Client\Test\Provider;
 
+use GuzzleHttp\Exception\BadResponseException;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
@@ -327,11 +328,17 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             '{"error":"Foo error","code":1337}'
         );
 
+        $request = m::mock('Psr\Http\Message\RequestInterface');
+
         $response = m::mock('Psr\Http\Message\ResponseInterface');
+        $response->shouldReceive('getStatusCode')->times(1)->andReturn(400);
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
 
-        $exception = m::mock('GuzzleHttp\Exception\BadResponseException');
-        $exception->shouldReceive('getResponse')->andReturn($response);
+        $exception = new BadResponseException(
+            'test exception',
+            $request,
+            $response
+        );
 
         $method = $provider->getAccessTokenMethod();
         $url    = $provider->urlAccessToken();

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -267,65 +267,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertRegExp('/^[a-zA-Z0-9\/+]{32}$/', $qs['state']);
     }
 
-    public function testGetAccessToken()
-    {
-        $provider = new MockProvider([
-          'clientId' => 'mock_client_id',
-          'clientSecret' => 'mock_secret',
-          'redirectUri' => 'none',
-        ]);
-
-        $grant_name = 'mock';
-        $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'uid' => 3];
-        $token = new AccessToken($raw_response);
-
-        $contains_correct_grant_type = function ($params) use ($grant_name) {
-            return is_array($params) && $params['grant_type'] === $grant_name;
-        };
-
-        $grant = m::mock('League\OAuth2\Client\Grant\GrantInterface');
-        $grant->shouldReceive('__toString')
-              ->times(1)
-              ->andReturn($grant_name);
-        $grant->shouldReceive('prepRequestParams')
-              ->with(
-                  m::on($contains_correct_grant_type),
-                  m::type('array')
-              )
-              ->andReturn([]);
-        $grant->shouldReceive('handleResponse')
-              ->with($raw_response)
-              ->andReturn($token);
-
-        $stream = m::mock('Psr\Http\Message\StreamInterface');
-        $stream->shouldReceive('__toString')->times(1)->andReturn(
-            json_encode($raw_response)
-        );
-
-        $response = m::mock('Psr\Http\Message\ResponseInterface');
-        $response->shouldReceive('getBody')->times(1)->andReturn($stream);
-
-        $method = $provider::ACCESS_TOKEN_METHOD;
-        $url = $provider->urlAccessToken();
-
-        $client = m::mock('GuzzleHttp\ClientInterface');
-        $client->shouldReceive('send')->with(
-            m::on(function ($request) use ($method, $url) {
-                return $request->getMethod() === $method
-                    && (string) $request->getUri() === $url;
-            })
-        )->times(1)->andReturn($response);
-
-        $provider->setHttpClient($client);
-
-        $result = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code']);
-
-        $this->assertSame($result, $token);
-        $this->assertSame($raw_response['uid'], $token->getUid());
-        $this->assertSame($raw_response['access_token'], $token->getToken());
-        $this->assertSame($raw_response['expires'], $token->getExpires());
-    }
-
     public function testErrorResponsesCanBeCustomizedAtTheProvider()
     {
         $provider = new MockProvider([
@@ -333,6 +274,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
           'clientSecret' => 'mock_secret',
           'redirectUri' => 'none',
         ]);
+
 
         $stream = m::mock('Psr\Http\Message\StreamInterface');
         $stream->shouldReceive('__toString')->times(1)->andReturn(
@@ -342,7 +284,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
 
-        $method = $provider::ACCESS_TOKEN_METHOD;
+        $method = $provider->getAccessTokenMethod();
         $url = $provider->urlAccessToken();
 
         $client = m::mock('GuzzleHttp\ClientInterface');
@@ -391,7 +333,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $exception = m::mock('GuzzleHttp\Exception\BadResponseException');
         $exception->shouldReceive('getResponse')->andReturn($response);
 
-        $method = $provider::ACCESS_TOKEN_METHOD;
+        $method = $provider->getAccessTokenMethod();
         $url    = $provider->urlAccessToken();
 
         $client = m::mock('GuzzleHttp\ClientInterface');
@@ -426,7 +368,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
 
-        $method = $provider::ACCESS_TOKEN_METHOD;
+        $method = $provider->getAccessTokenMethod();
         $url    = $provider->urlAccessToken();
 
         $client = m::mock('GuzzleHttp\ClientInterface');
@@ -471,5 +413,91 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         // Final result should be a parsed response
         $result = $provider->getResponse($request);
         $this->assertSame(['example' => 'response'], $result);
+    }
+
+    public function getAccessTokenMethodProvider()
+    {
+        return [
+            ['GET'],
+            ['POST'],
+        ];
+    }
+
+    /**
+     * @dataProvider getAccessTokenMethodProvider
+     */
+    public function testGetAccessToken($method)
+    {
+        $provider = new MockProvider([
+          'clientId' => 'mock_client_id',
+          'clientSecret' => 'mock_secret',
+          'redirectUri' => 'none',
+        ]);
+
+        $provider->setAccessTokenMethod($method);
+
+        $grant_name = 'mock';
+        $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'uid' => 3];
+        $token = new AccessToken($raw_response);
+
+        $contains_correct_grant_type = function ($params) use ($grant_name) {
+            return is_array($params) && $params['grant_type'] === $grant_name;
+        };
+
+        $grant = m::mock('League\OAuth2\Client\Grant\GrantInterface');
+        $grant->shouldReceive('__toString')
+              ->times(1)
+              ->andReturn($grant_name);
+        $grant->shouldReceive('prepRequestParams')
+              ->with(
+                  m::on($contains_correct_grant_type),
+                  m::type('array')
+              )
+              ->andReturn([]);
+        $grant->shouldReceive('handleResponse')
+              ->with($raw_response)
+              ->andReturn($token);
+
+        $stream = m::mock('Psr\Http\Message\StreamInterface');
+        $stream->shouldReceive('__toString')->times(1)->andReturn(
+            json_encode($raw_response)
+        );
+
+        $response = m::mock('Psr\Http\Message\ResponseInterface');
+        $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+
+        $url = $provider->urlAccessToken();
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')->with(
+            m::on(function ($request) use ($method, $url) {
+                return $request->getMethod() === $method
+                    && (string) $request->getUri() === $url;
+            })
+        )->times(1)->andReturn($response);
+
+        $provider->setHttpClient($client);
+
+        $result = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code']);
+
+        $this->assertSame($result, $token);
+        $this->assertSame($raw_response['uid'], $token->getUid());
+        $this->assertSame($raw_response['access_token'], $token->getToken());
+        $this->assertSame($raw_response['expires'], $token->getExpires());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidAccessTokenMethod()
+    {
+        $provider = new MockProvider([
+          'clientId' => 'mock_client_id',
+          'clientSecret' => 'mock_secret',
+          'redirectUri' => 'none',
+        ]);
+
+        $provider->setAccessTokenMethod('PUT');
+        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 }

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -11,6 +11,8 @@ class Fake extends AbstractProvider
 {
     use BearerAuthorizationTrait;
 
+    private $accessTokenMethod = 'POST';
+
     public function urlAuthorize()
     {
         return 'http://example.com/oauth/authorize';
@@ -29,6 +31,16 @@ class Fake extends AbstractProvider
     protected function getDefaultScopes()
     {
         return ['test'];
+    }
+
+    public function setAccessTokenMethod($method)
+    {
+        $this->accessTokenMethod = $method;
+    }
+
+    public function getAccessTokenMethod()
+    {
+        return $this->accessTokenMethod;
     }
 
     protected function prepareUserDetails(array $response, AccessToken $token)

--- a/test/src/Tool/RequestFactoryTest.php
+++ b/test/src/Tool/RequestFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace League\OAuth2\Client\Test\Tool;
+
+use League\OAuth2\Client\Tool\RequestFactory;
+use Mockery as m;
+
+class RequestFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->factory = new RequestFactory;
+    }
+
+    public function testGetRequest()
+    {
+        $method  = 'get';
+        $uri     = '/test';
+
+        $request = $this->factory->getRequest($method, $uri);
+
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
+        $this->assertSame(strtoupper($method), $request->getMethod());
+        $this->assertSame($uri, (string) $request->getUri());
+
+        $headers         = ['X-Test' => 'Foo'];
+        $body            = 'test body';
+        $protocolVersion = '1.0';
+
+        $request = $this->factory->getRequest($method, $uri, $headers, $body, $protocolVersion);
+
+        $this->assertTrue($request->hasHeader('X-Test'));
+        $this->assertSame($body, (string) $request->getBody());
+        $this->assertSame($protocolVersion, $request->getProtocolVersion());
+    }
+
+    public function testGetRequestWithOptions()
+    {
+        $method  = 'head';
+        $uri     = '/test/options';
+
+        $request = $this->factory->getRequestWithOptions($method, $uri);
+
+        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
+        $this->assertSame(strtoupper($method), $request->getMethod());
+        $this->assertSame($uri, (string) $request->getUri());
+
+        $options = [
+            'body'    => 'another=test&form=body',
+            'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
+        ];
+
+        $request = $this->factory->getRequestWithOptions($method, $uri, $options);
+
+        $this->assertContains($options['headers']['Content-Type'], $request->getHeader('Content-Type'));
+        $this->assertSame($options['body'], (string) $request->getBody());
+    }
+}


### PR DESCRIPTION
Replaces Ivory HTTP adapter with Guzzle 6. Moves towards better PSR-7 compliance.

Also bumps the PHP version requirement to 5.5, because Guzzle 6 requires it.

Fixes #314 