### PR TITLE
If there is an error parsing a JSON response set the response as the error.

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -232,6 +232,8 @@ abstract class AbstractProvider implements ProviderInterface
 
                 if (JSON_ERROR_NONE === json_last_error()) {
                     $result = $json;
+                } elseif(json_last_error()){                    
+                    $result['error'] = $response;
                 }
 
                 break;


### PR DESCRIPTION
When connecting to a shitty API that returns a text error (or an HTML error)  even though we are expecting JSON, then we should escalate the text error otherwise all you get is "Unknown Error" which is super unhelpful.