### PR TITLE
Check if property `publicProfileUrl` exists in LinkedIn response

### DIFF
--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -39,6 +39,7 @@ class LinkedIn extends AbstractProvider
         $location = (isset($response->location->name)) ? $response->location->name : null;
         $description = (isset($response->headline)) ? $response->headline : null;
         $pictureUrl = (isset($response->pictureUrl)) ? $response->pictureUrl : null;
+        $publicProfileUrl = (isset($response->publicProfileUrl)) ? $response->publicProfileUrl : null;
 
         $user->exchangeArray([
             'uid' => $response->id,
@@ -49,7 +50,7 @@ class LinkedIn extends AbstractProvider
             'location' => $location,
             'description' => $description,
             'imageurl' => $pictureUrl,
-            'urls' => $response->publicProfileUrl,
+            'urls' => $publicProfileUrl,
         ]);
 
         return $user;


### PR DESCRIPTION
There is a scenario where the publicProfileUrl is not set, which results in a PHP notice.