### PR TITLE
Use "Content-Type" headers to parse response

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -342,12 +342,13 @@ abstract class AbstractProvider implements ProviderInterface
         $request  = $this->getRequest($method, $url, $options);
         $response = $this->getResponse($request);
 
-        $result = $this->parseResponse($response);
+        $this->checkResponse($response);
 
-        $result = $this->prepareAccessTokenResult($result);
+        $response = $this->prepareAccessTokenResult($response);
 
-        return $grant->handleResponse($result);
+        return $grant->handleResponse($response);
     }
+
 
     /**
      * Get a request instance.
@@ -417,7 +418,9 @@ abstract class AbstractProvider implements ProviderInterface
     {
         $content = json_decode($content, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new UnexpectedValueException('Failed to parse JSON response');
+            throw new UnexpectedValueException(
+                "Failed to parse JSON response: ".json_last_error_msg()
+            );
         }
         return $content;
     }
@@ -508,7 +511,6 @@ abstract class AbstractProvider implements ProviderInterface
      * @param  null|integer $enc_type
      *
      * @return string
-     * @codeCoverageIgnoreStart
      */
     protected function httpBuildQuery($params, $numeric_prefix = 0, $arg_separator = '&', $enc_type = null)
     {

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -378,10 +378,6 @@ abstract class AbstractProvider implements ProviderInterface
         return $this->parseResponse($response);
     }
 
-    protected function getContentType(ResponseInterface $response)
-    {
-        return join(";", (array) $response->getHeader('content-type'));
-    }
 
     protected function parseJson($content)
     {
@@ -390,6 +386,17 @@ abstract class AbstractProvider implements ProviderInterface
             throw new UnexpectedValueException('Failed to parse JSON response');
         }
         return $content;
+    }
+
+    /**
+     * Returns the content type header of a response.
+     *
+     * @param ResponseInterface $response
+     * @return string A semi-colon separated join of content-type headers.
+     */
+    protected function getContentType(ResponseInterface $response)
+    {
+        return join(";", (array) $response->getHeader('content-type'));
     }
 
     /**

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -387,29 +387,28 @@ abstract class AbstractProvider implements ProviderInterface
     {
         $content = json_decode($content, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new UnexpectedValueException('Unable to parse client response');
+            throw new UnexpectedValueException('Failed to parse JSON response');
         }
         return $content;
     }
 
     /**
-     * Parse the response, according to the provider response type.
+     * Parses the response, according to the response's content-type header.
      *
      * @throws UnexpectedValueException
-     * @param  string $response
+     * @param  ResponseInterface $response
      * @return array
      */
     protected function parseResponse(ResponseInterface $response)
     {
         $content = (string) $response->getBody();
+        $type = $this->getContentType($response);
 
-        $contentType = $this->getContentType($response);
-
-        if (strpos($contentType, "json") !== false) {
+        if (strpos($type, "json") !== false) {
             return $this->parseJson($content);
         }
 
-        if (strpos($contentType, "urlencoded") !== false) {
+        if (strpos($type, "urlencoded") !== false) {
             parse_str($content, $parsed);
             return $parsed;
         }

--- a/test/src/Grant/GrantTestCase.php
+++ b/test/src/Grant/GrantTestCase.php
@@ -57,6 +57,10 @@ abstract class GrantTestCase extends \PHPUnit_Framework_TestCase
         $response = m::mock('Ivory\HttpAdapter\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
 
+        $response->shouldReceive('getHeader')
+                 ->times(1)
+                 ->andReturn('application/json');
+
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
         $client->shouldReceive('post')->with(
             $this->provider->urlAccessToken(),

--- a/test/src/Grant/GrantTestCase.php
+++ b/test/src/Grant/GrantTestCase.php
@@ -56,6 +56,7 @@ abstract class GrantTestCase extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $paramCheck = $this->getParamExpectation();
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -144,6 +144,10 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                  ->times(1)
                  ->andReturn(json_encode(compact('id', 'name', 'email')));
 
+        $response->shouldReceive('getHeader')
+                 ->times(1)
+                 ->andReturn('application/json');
+
         $factory = m::mock('Ivory\HttpAdapter\Message\MessageFactoryInterface');
         $factory->shouldReceive('createRequest')->times(1)->andReturn($request);
 
@@ -293,6 +297,10 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                  ->times(1)
                  ->andReturn(json_encode($raw_response));
 
+        $response->shouldReceive('getHeader')
+                 ->times(1)
+                 ->andReturn('application/json');
+
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
         $client->shouldReceive('post')
             ->with(
@@ -325,6 +333,10 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                  ->times(1)
                  ->andReturn('{"error":"Foo error","code":1337}');
 
+        $response->shouldReceive('getHeader')
+                 ->times(1)
+                 ->andReturn('application/json');
+
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
         $client->shouldReceive('post')
             ->with(
@@ -333,6 +345,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                 $params = m::type('array')
             )
             ->times(1)->andReturn($response);
+
         $provider->setHttpClient($client);
 
         $errorMessage = '';
@@ -386,6 +399,10 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                  ->times(1)
                  ->andReturn('{"error":"BadResponse","code":500}');
 
+        $response->shouldReceive('getHeader')
+                 ->times(1)
+                 ->andReturn('application/json');
+
         $exception = new HttpAdapterException();
         $exception->setResponse($response);
 
@@ -418,6 +435,10 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                  ->times(1)
                  ->andReturn('not json');
 
+        $response->shouldReceive('getHeader')
+                 ->times(1)
+                 ->andReturn('application/json');
+
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
         $client->shouldReceive('post')
             ->with(
@@ -448,6 +469,10 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response->shouldReceive('getBody')
                  ->times(1)
                  ->andReturn('{"example":"response"}');
+
+        $response->shouldReceive('getHeader')
+                 ->times(1)
+                 ->andReturn('application/json');
 
         $client = m::mock('Ivory\HttpAdapter\HttpAdapterInterface');
         $client->shouldReceive('sendRequest')

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -154,7 +154,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
-
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $url = $provider->urlUserDetails($token);
 
@@ -284,6 +284,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $method = $provider->getAccessTokenMethod();
         $url = $provider->urlAccessToken();
@@ -333,11 +334,11 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
-        $response->shouldReceive('getStatusCode')->times(3)->andReturn(403);
+        $response->shouldReceive('getStatusCode')->atLeast(1)->andReturn(403);
         $response->shouldReceive('getReasonPhrase')->times(1)->andReturn('n/a');
+        $response->shouldReceive('getHeader')->with('content-type')->andReturn('application/json');
 
         $exception = BadResponseException::create($request, $response);
-
 
         $method = $provider->getAccessTokenMethod();
         $url    = $provider->urlAccessToken();
@@ -351,41 +352,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         )->times(1)->andThrow($exception);
 
         $provider->setHttpClient($client);
-        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
-    }
-
-    /**
-     * @expectedException \UnexpectedValueException
-     */
-    public function testParseResponseJsonFailure()
-    {
-        $provider = new MockProvider([
-          'clientId' => 'mock_client_id',
-          'clientSecret' => 'mock_secret',
-          'redirectUri' => 'none',
-        ]);
-
-        $stream = m::mock('Psr\Http\Message\StreamInterface');
-        $stream->shouldReceive('__toString')->times(1)->andReturn(
-            'not json'
-        );
-
-        $response = m::mock('Psr\Http\Message\ResponseInterface');
-        $response->shouldReceive('getBody')->times(1)->andReturn($stream);
-
-        $method = $provider->getAccessTokenMethod();
-        $url    = $provider->urlAccessToken();
-
-        $client = m::mock('GuzzleHttp\ClientInterface');
-        $client->shouldReceive('send')->with(
-            m::on(function ($request) use ($method, $url) {
-                return $request->getMethod() === $method
-                    && (string) $request->getUri() === $url;
-            })
-        )->times(1)->andReturn($response);
-
-        $provider->setHttpClient($client);
-
         $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 
@@ -409,6 +375,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $client = m::mock('GuzzleHttp\ClientInterface');
         $client->shouldReceive('send')->with($request)->andReturn($response);
@@ -470,6 +437,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $url = $provider->urlAccessToken();
 
@@ -504,5 +472,50 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $provider->setAccessTokenMethod('PUT');
         $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
+
+    public function getPrivateMethod($class, $name) {
+      $class = new \ReflectionClass($class);
+      $method = $class->getMethod($name);
+      $this->assertFalse($method->isPublic());
+      $method->setAccessible(true);
+      return $method;
+    }
+
+    private function _testParse($body, $type, $expected = null)
+    {
+        $method = $this->getPrivateMethod('League\OAuth2\Client\Provider\AbstractProvider', 'parseResponse');
+
+        $stream = m::mock('Psr\Http\Message\StreamInterface');
+        $stream->shouldReceive('__toString')->times(1)->andReturn($body);
+
+        $response = m::mock('Psr\Http\Message\ResponseInterface');
+        $response->shouldReceive('getBody')->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->andReturn($type);
+
+        $this->assertEquals($expected, $method->invoke($this->provider, $response));
+    }
+
+    public function testParseJson()
+    {
+        $this->_testParse('{"a": 1}', 'application/json', ['a' => 1]);
+    }
+
+    public function testParseUnknownType()
+    {
+        $this->_testParse('success', 'unknown/mime', 'success');
+    }
+
+    public function testParseUrlParams()
+    {
+        $this->_testParse('a=1&b=2', 'application/x-www-form-urlencoded', ['a' => 1, 'b' => 2]);
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testParseResponseJsonFailure()
+    {
+        $this->_testParse('{a: 1}', 'application/json');
     }
 }

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -36,7 +36,7 @@ class Fake extends AbstractProvider
         return new Fake\User($response);
     }
 
-    protected function checkResponse(array $response)
+    protected function checkResponse($response)
     {
         if (!empty($response['error'])) {
             throw new IdentityProviderException($response['error'], $response['code'], $response);


### PR DESCRIPTION
There has been a few cases where relying on a static expected response type is problematic. @SammyK mentioned that Facebook is inconsistent between API versions, so we added a dynamic way to get the response type in #301.

This pull request takes that one step further, and determines the response type by looking at the content-type headers returned by the response. I believe that this is more reliable and allows handling of API's / hosts that send multiple content types (for example Reddit sending image/png for some endpoints).