### PR TITLE
Use "Content-Type" headers to parse response

### DIFF
--- a/test/src/Grant/GrantTestCase.php
+++ b/test/src/Grant/GrantTestCase.php
@@ -56,6 +56,7 @@ abstract class GrantTestCase extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $paramCheck = $this->getParamExpectation();
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -154,6 +154,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $url = $provider->urlUserDetails($token);
 
@@ -284,6 +285,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $method = $provider->getAccessTokenMethod();
         $url = $provider->urlAccessToken();
@@ -333,6 +335,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getStatusCode')->times(1)->andReturn(400);
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->andReturn('application/json');
 
         $exception = new BadResponseException(
             'test exception',
@@ -352,42 +355,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         )->times(1)->andThrow($exception);
 
         $provider->setHttpClient($client);
-
-        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
-    }
-
-    /**
-     * @expectedException \UnexpectedValueException
-     */
-    public function testParseResponseJsonFailure()
-    {
-        $provider = new MockProvider([
-          'clientId' => 'mock_client_id',
-          'clientSecret' => 'mock_secret',
-          'redirectUri' => 'none',
-        ]);
-
-        $stream = m::mock('Psr\Http\Message\StreamInterface');
-        $stream->shouldReceive('__toString')->times(1)->andReturn(
-            'not json'
-        );
-
-        $response = m::mock('Psr\Http\Message\ResponseInterface');
-        $response->shouldReceive('getBody')->times(1)->andReturn($stream);
-
-        $method = $provider->getAccessTokenMethod();
-        $url    = $provider->urlAccessToken();
-
-        $client = m::mock('GuzzleHttp\ClientInterface');
-        $client->shouldReceive('send')->with(
-            m::on(function ($request) use ($method, $url) {
-                return $request->getMethod() === $method
-                    && (string) $request->getUri() === $url;
-            })
-        )->times(1)->andReturn($response);
-
-        $provider->setHttpClient($client);
-
         $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 
@@ -411,6 +378,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $client = m::mock('GuzzleHttp\ClientInterface');
         $client->shouldReceive('send')->with($request)->andReturn($response);
@@ -472,8 +440,10 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $response = m::mock('Psr\Http\Message\ResponseInterface');
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
-        $url = $provider->urlAccessToken();
+        $method = $provider->getAccessTokenMethod();
+        $url    = $provider->urlAccessToken();
 
         $client = m::mock('GuzzleHttp\ClientInterface');
         $client->shouldReceive('send')->with(
@@ -506,5 +476,51 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $provider->setAccessTokenMethod('PUT');
         $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
+
+    public function getPrivateMethod($class, $name)
+    {
+        $class = new \ReflectionClass($class);
+        $method = $class->getMethod($name);
+        $this->assertFalse($method->isPublic());
+        $method->setAccessible(true);
+        return $method;
+    }
+
+    private function _testParse($body, $type, $expected = null)
+    {
+        $method = $this->getPrivateMethod('League\OAuth2\Client\Provider\AbstractProvider', 'parseResponse');
+
+        $stream = m::mock('Psr\Http\Message\StreamInterface');
+        $stream->shouldReceive('__toString')->times(1)->andReturn($body);
+
+        $response = m::mock('Psr\Http\Message\ResponseInterface');
+        $response->shouldReceive('getBody')->andReturn($stream);
+        $response->shouldReceive('getHeader')->with('content-type')->andReturn($type);
+
+        $this->assertEquals($expected, $method->invoke($this->provider, $response));
+    }
+
+    public function testParseJson()
+    {
+        $this->_testParse('{"a": 1}', 'application/json', ['a' => 1]);
+    }
+
+    public function testParseUnknownType()
+    {
+        $this->_testParse('success', 'unknown/mime', 'success');
+    }
+
+    public function testParseUrlParams()
+    {
+        $this->_testParse('a=1&b=2', 'application/x-www-form-urlencoded', ['a' => 1, 'b' => 2]);
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testParseResponseJsonFailure()
+    {
+        $this->_testParse('{a: 1}', 'application/json');
     }
 }

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -48,7 +48,7 @@ class Fake extends AbstractProvider
         return new Fake\User($response);
     }
 
-    protected function checkResponse(array $response)
+    protected function checkResponse($response)
     {
         if (!empty($response['error'])) {
             throw new IdentityProviderException($response['error'], $response['code'], $response);


### PR DESCRIPTION
There has been a few cases where relying on a static expected response type is problematic. @SammyK mentioned that Facebook is inconsistent between API versions, so we added a dynamic way to get the response type in #301.

This pull request takes that one step further, and determines the response type by looking at the content-type headers returned by the response. I believe that this is more reliable and allows handling of API's / hosts that send multiple content types (for example Reddit sending image/png for some endpoints).