### PR TITLE
Class name resolution as scalar with "class" keyword

### DIFF
--- a/src/Grant/GrantFactory.php
+++ b/src/Grant/GrantFactory.php
@@ -65,7 +65,7 @@ class GrantFactory
      */
     public function isGrant($class)
     {
-        return is_subclass_of($class, 'League\OAuth2\Client\Grant\GrantInterface');
+        return is_subclass_of($class, GrantInterface::class);
     }
 
     /**

--- a/test/src/Grant/GrantFactoryTest.php
+++ b/test/src/Grant/GrantFactoryTest.php
@@ -3,6 +3,7 @@
 namespace League\OAuth2\Client\Test\Grant;
 
 use League\OAuth2\Client\Grant\GrantFactory;
+use League\OAuth2\Client\Grant\GrantInterface;
 use League\OAuth2\Client\Grant\InvalidGrantException;
 use League\OAuth2\Client\Test\Grant\Fake as MockGrant;
 use Mockery as m;
@@ -31,7 +32,7 @@ class GrantFactoryTest extends \PHPUnit_Framework_TestCase
     public function testGetGrantDefaults($name)
     {
         $grant = $this->factory->getGrant($name);
-        $this->assertInstanceOf('League\OAuth2\Client\Grant\GrantInterface', $grant);
+        $this->assertInstanceOf(GrantInterface::class, $grant);
     }
 
     public function providerGetGrantDefaults()

--- a/test/src/Grant/GrantTestCase.php
+++ b/test/src/Grant/GrantTestCase.php
@@ -2,6 +2,9 @@
 
 namespace League\OAuth2\Client\Test\Grant;
 
+use GuzzleHttp\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use League\OAuth2\Client\Test\Provider\Fake as MockProvider;
 use Mockery as m;
 
@@ -49,17 +52,17 @@ abstract class GrantTestCase extends \PHPUnit_Framework_TestCase
      */
     public function testGetAccessToken($grant, array $params = [])
     {
-        $stream = m::mock('Psr\Http\Message\StreamInterface');
+        $stream = m::mock(StreamInterface::class);
         $stream->shouldReceive('__toString')->times(1)->andReturn(
             '{"access_token": "mock_access_token", "expires": 3600, "refresh_token": "mock_refresh_token", "uid": 1}'
         );
 
-        $response = m::mock('Psr\Http\Message\ResponseInterface');
+        $response = m::mock(ResponseInterface::class);
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
 
         $paramCheck = $this->getParamExpectation();
 
-        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client = m::mock(ClientInterface::class);
         $client->shouldReceive('send')->with(
             $request = m::on(function ($request) use ($paramCheck) {
                 parse_str((string) $request->getBody(), $body);

--- a/test/src/Tool/RequestFactoryTest.php
+++ b/test/src/Tool/RequestFactoryTest.php
@@ -3,6 +3,7 @@
 namespace League\OAuth2\Client\Test\Tool;
 
 use League\OAuth2\Client\Tool\RequestFactory;
+use Psr\Http\Message\RequestInterface;
 use Mockery as m;
 
 class RequestFactoryTest extends \PHPUnit_Framework_TestCase
@@ -19,7 +20,7 @@ class RequestFactoryTest extends \PHPUnit_Framework_TestCase
 
         $request = $this->factory->getRequest($method, $uri);
 
-        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
+        $this->assertInstanceOf(RequestInterface::class, $request);
         $this->assertSame(strtoupper($method), $request->getMethod());
         $this->assertSame($uri, (string) $request->getUri());
 
@@ -41,7 +42,7 @@ class RequestFactoryTest extends \PHPUnit_Framework_TestCase
 
         $request = $this->factory->getRequestWithOptions($method, $uri);
 
-        $this->assertInstanceOf('Psr\Http\Message\RequestInterface', $request);
+        $this->assertInstanceOf(RequestInterface::class, $request);
         $this->assertSame(strtoupper($method), $request->getMethod());
         $this->assertSame($uri, (string) $request->getUri());
 


### PR DESCRIPTION
A proposed change from explicit string class names to namespaced resolution, meaning if we want to change the class we are using, we only need to `use` a different class and alias accordingly. This is only possible now that we're on version >= 5.5 for the 1.0 branch.

Eg.

`'Psr\Http\Message\StreamInterface` --> `StreamInterface::class`.