### PR TITLE
Set correct scope separator for Instagram

### DIFF
--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -6,6 +6,7 @@ use League\OAuth2\Client\Entity\User;
 
 class Instagram extends AbstractProvider
 {
+    public $scopeSeparator = '+';
     public $scopes = ['basic'];
     public $responseType = 'json';
 


### PR DESCRIPTION
Instagram's scope separator is `+`, as documented [here](https://instagram.com/developer/authentication/#scope). This patch fixes that on `master`.