### PR TITLE
Fixing provider state in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ if (!isset($_GET['code'])) {
 
     // If we don't have an authorization code then get one
     $authUrl = $provider->getAuthorizationUrl();
-    $_SESSION['oauth2state'] = $provider->state;
+    $_SESSION['oauth2state'] = $provider->getState();
     header('Location: '.$authUrl);
     exit;
 


### PR DESCRIPTION
It's a protected variable, users should use `getState()` instead.