### PR TITLE
Added support for JSONP responses

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -537,7 +537,9 @@ abstract class AbstractProvider
         $content = (string) $response->getBody();
         $type = $this->getContentType($response);
 
-        if (strpos($type, "json") !== false) {
+        // JSON  = application/json
+        // JSONP = application/javascript
+        if (strpos($type, "json") !== false || strpos($type, "javascript") !== false) {
             return $this->parseJson($content);
         }
 

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -522,7 +522,7 @@ abstract class AbstractProvider
      */
     protected function getContentType(ResponseInterface $response)
     {
-        return join(";", (array) $response->getHeader('content-type'));
+        return join(';', (array) $response->getHeader('content-type'));
     }
 
     /**
@@ -539,11 +539,11 @@ abstract class AbstractProvider
 
         // JSON  = application/json
         // JSONP = application/javascript
-        if (strpos($type, "json") !== false || strpos($type, "javascript") !== false) {
+        if (strpos($type, 'json') !== false || strpos($type, 'javascript') !== false) {
             return $this->parseJson($content);
         }
 
-        if (strpos($type, "urlencoded") !== false) {
+        if (strpos($type, 'urlencoded') !== false) {
             parse_str($content, $parsed);
             return $parsed;
         }


### PR DESCRIPTION
Most of Facebook responses are of type [JSONP](https://en.wikipedia.org/wiki/JSONP) which have a [content-type header of `application/javascript`](http://stackoverflow.com/questions/477816/what-is-the-correct-json-content-type#answers-header). This PR adds support to properly decode JSONP responses.