### PR TITLE
Single quotes in the context of content types

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -522,7 +522,7 @@ abstract class AbstractProvider
      */
     protected function getContentType(ResponseInterface $response)
     {
-        return join(";", (array) $response->getHeader('content-type'));
+        return join(';', (array) $response->getHeader('content-type'));
     }
 
     /**
@@ -537,11 +537,11 @@ abstract class AbstractProvider
         $content = (string) $response->getBody();
         $type = $this->getContentType($response);
 
-        if (strpos($type, "json") !== false) {
+        if (strpos($type, 'json') !== false) {
             return $this->parseJson($content);
         }
 
-        if (strpos($type, "urlencoded") !== false) {
+        if (strpos($type, 'urlencoded') !== false) {
             parse_str($content, $parsed);
             return $parsed;
         }


### PR DESCRIPTION
As mentioned and then orphaned in #341, this fixes some double quotes that should be single quotes for the sake of consistency.