### PR TITLE
A push for consistent nomenclature

### DIFF
--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -20,19 +20,19 @@ abstract class AbstractGrant implements GrantInterface
      *
      * @return array
      */
-    abstract protected function getRequiredRequestParams();
+    abstract protected function getRequiredRequestParameters();
 
-    public function prepRequestParams(array $defaultParams, array $params)
+    public function prepareRequestParameters(array $defaults, array $params)
     {
         $this->checkRequiredParameters(
-            $this->getRequiredRequestParams(),
+            $this->getRequiredRequestParameters(),
             $params
         );
 
-        return array_merge($defaultParams, $params);
+        return array_merge($defaults, $params);
     }
 
-    public function handleResponse(array $response)
+    public function createAccessToken(array $response)
     {
         return new AccessToken($response);
     }

--- a/src/Grant/AuthorizationCode.php
+++ b/src/Grant/AuthorizationCode.php
@@ -9,7 +9,7 @@ class AuthorizationCode extends AbstractGrant
         return 'authorization_code';
     }
 
-    protected function getRequiredRequestParams()
+    protected function getRequiredRequestParameters()
     {
         return [
             'code',

--- a/src/Grant/ClientCredentials.php
+++ b/src/Grant/ClientCredentials.php
@@ -9,7 +9,7 @@ class ClientCredentials extends AbstractGrant
         return 'client_credentials';
     }
 
-    protected function getRequiredRequestParams()
+    protected function getRequiredRequestParameters()
     {
         return [];
     }

--- a/src/Grant/GrantInterface.php
+++ b/src/Grant/GrantInterface.php
@@ -18,11 +18,11 @@ interface GrantInterface
      * If required parameters are not defined, an exception should be thrown.
      *
      * @throws BadMethodCallException
-     * @param  array $defaultParams
+     * @param  array $defaults
      * @param  array $params
      * @return array
      */
-    public function prepRequestParams(array $defaultParams, array $params);
+    public function prepareRequestParameters(array $defaults, array $params);
 
     /**
      * Generate an access token from a successful authorization request.
@@ -30,5 +30,5 @@ interface GrantInterface
      * @param  array $response
      * @return League\OAuth2\Client\Token\AccessToken
      */
-    public function handleResponse(array $response);
+    public function createAccessToken(array $response);
 }

--- a/src/Grant/Password.php
+++ b/src/Grant/Password.php
@@ -9,7 +9,7 @@ class Password extends AbstractGrant
         return 'password';
     }
 
-    protected function getRequiredRequestParams()
+    protected function getRequiredRequestParameters()
     {
         return [
             'username',

--- a/src/Grant/RefreshToken.php
+++ b/src/Grant/RefreshToken.php
@@ -9,7 +9,7 @@ class RefreshToken extends AbstractGrant
         return 'refresh_token';
     }
 
-    protected function getRequiredRequestParams()
+    protected function getRequiredRequestParameters()
     {
         return [
             'refresh_token',

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -208,9 +208,9 @@ abstract class AbstractProvider
         return $this->state;
     }
 
-    abstract public function urlAuthorize();
-    abstract public function urlAccessToken();
-    abstract public function urlUserDetails(AccessToken $token);
+    abstract public function getBaseAuthorizationUrl();
+    abstract public function getBaseAccessTokenUrl();
+    abstract public function getUserDetailsUrl(AccessToken $token);
 
     /**
      * Get a new random string to use for auth state.
@@ -294,7 +294,7 @@ abstract class AbstractProvider
      */
     public function getAuthorizationUrl(array $options = [])
     {
-        $base   = $this->urlAuthorize();
+        $base   = $this->getBaseAuthorizationUrl();
         $params = $this->getAuthorizationParameters($options);
         $query  = $this->getAuthorizationQuery($params);
 
@@ -378,7 +378,7 @@ abstract class AbstractProvider
      */
     protected function getAccessTokenRequest(array $params)
     {
-        $url = $this->urlAccessToken();
+        $url = $this->getBaseAccessTokenUrl();
         $query = $this->getAccessTokenQuery($params);
         $method = strtoupper($this->getAccessTokenMethod());
 
@@ -417,7 +417,7 @@ abstract class AbstractProvider
             'grant_type'    => (string) $grant,
         ];
 
-        $params   = $grant->prepRequestParams($params, $options);
+        $params   = $grant->prepareRequestParameters($params, $options);
         $request  = $this->getAccessTokenRequest($params);
         $response = $this->getResponse($request);
 
@@ -425,7 +425,7 @@ abstract class AbstractProvider
 
         $response = $this->prepareAccessTokenResponse($response);
 
-        return $grant->handleResponse($response);
+        return $grant->createAccessToken($response);
     }
 
 
@@ -593,7 +593,7 @@ abstract class AbstractProvider
 
     protected function fetchUserDetails(AccessToken $token)
     {
-        $url = $this->urlUserDetails($token);
+        $url = $this->getUserDetailsUrl($token);
 
         $request = $this->getAuthenticatedRequest('GET', $url, $token);
 

--- a/test/src/Grant/Fake.php
+++ b/test/src/Grant/Fake.php
@@ -12,12 +12,12 @@ class Fake implements GrantInterface
         return 'fake';
     }
 
-    public function prepRequestParams(array $defaultParams, array $params)
+    public function prepareRequestParameters(array $defaultParams, array $params)
     {
         return array_merge($defaultParams, $params);
     }
 
-    public function handleResponse(array $response = [])
+    public function createAccessToken(array $response = [])
     {
         return new AccessToken($response);
     }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -165,7 +165,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
         $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
-        $url = $provider->urlUserDetails($token);
+        $url = $provider->getUserDetailsUrl($token);
 
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('send')->with(
@@ -297,7 +297,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $method = $provider->getAccessTokenMethod();
-        $url = $provider->urlAccessToken();
+        $url = $provider->getBaseAccessTokenUrl();
 
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('send')->with(
@@ -353,7 +353,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         );
 
         $method = $provider->getAccessTokenMethod();
-        $url    = $provider->urlAccessToken();
+        $url    = $provider->getBaseAccessTokenUrl();
 
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('send')->with(
@@ -432,13 +432,13 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $grant->shouldReceive('__toString')
               ->times(1)
               ->andReturn($grant_name);
-        $grant->shouldReceive('prepRequestParams')
+        $grant->shouldReceive('prepareRequestParameters')
               ->with(
                   m::on($contains_correct_grant_type),
                   m::type('array')
               )
               ->andReturn([]);
-        $grant->shouldReceive('handleResponse')
+        $grant->shouldReceive('createAccessToken')
               ->with($raw_response)
               ->andReturn($token);
 
@@ -452,7 +452,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
         $method = $provider->getAccessTokenMethod();
-        $url    = $provider->urlAccessToken();
+        $url    = $provider->getBaseAccessTokenUrl();
 
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('send')->with(

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -13,17 +13,17 @@ class Fake extends AbstractProvider
 
     private $accessTokenMethod = 'POST';
 
-    public function urlAuthorize()
+    public function getBaseAuthorizationUrl()
     {
         return 'http://example.com/oauth/authorize';
     }
 
-    public function urlAccessToken()
+    public function getBaseAccessTokenUrl()
     {
         return 'http://example.com/oauth/token';
     }
 
-    public function urlUserDetails(AccessToken $token)
+    public function getUserDetailsUrl(AccessToken $token)
     {
         return 'http://example.com/oauth/user';
     }


### PR DESCRIPTION
> "The devising or choosing of names for things, especially in a science or other discipline."

I'm a firm believer that a consistent codebase is an intuitive codebase. This pull request is not important, and doesn't add any functionality; it's simply an attempt to improve the consistency of our naming.

**AbstractGrant**
- `getRequiredRequestParams` -> `getRequiredRequestParameters`
- `prepRequestParams ` -> `prepareRequestParameters `
- `handleResponse` -> `createAccessToken`

**AbstractProvider**
- `urlAuthorize` -> `getBaseAuthorizationUrl`
- `urlAccessToken` -> `getBaseAccessTokenUrl`
- `urlUserDetails` -> `getUserDetailsUrl`

These are not "change for the sake of change". You should be able to determine what a method does based on its name. `isValue`, `hasValue`, `setValue`, `getValue` etc are all staples.

`urlAuthorize` is internal, so could argue that it doesn't matter. But it always matters, even if it's private. It's not clear what `urlAuthorize` does; maybe attempt to authorize using a URL? I know it's a nitpick but if the goal is to write a solid, top shelf library, these are the kind of things that make a difference.