### PR TITLE
Updating scope sepearator and adding test to Instagram provider

### DIFF
--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -6,7 +6,7 @@ use League\OAuth2\Client\Entity\User;
 
 class Instagram extends AbstractProvider
 {
-    public $scopeSeparator = '+';
+    public $scopeSeparator = ' ';
     public $scopes = ['basic'];
     public $responseType = 'json';
 

--- a/test/src/Provider/InstagramTest.php
+++ b/test/src/Provider/InstagramTest.php
@@ -70,6 +70,11 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
     public function testScopes()
     {
         $this->assertEquals(['basic'], $this->provider->getScopes());
+
+        $this->provider->setScopes(['basic','likes']);
+        $authUrl = $this->provider->getAuthorizationUrl();
+
+        $this->assertContains('scope=basic+likes', $authUrl);
     }
 
     public function testUserData()


### PR DESCRIPTION
As per #335 

I've added a test to ensure the resulting authorization url is formatted correctly with the scope separator being a space.