### PR TITLE
Updating scope sepearator and adding test to LinkedIn provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,9 @@ $provider = new League\OAuth2\Client\Provider\LinkedIn([
     'clientId'          => '{linkedin-client-id}',
     'clientSecret'      => '{linkedin-client-secret}',
     'redirectUri'       => 'https://example.com/callback-url',
-    'scopes'            => ['r_basicprofile r_emailaddress'],
+    'scopes'            => ['r_basicprofile','r_emailaddress'],
 ]);
 ```
-It is important to note, each scope must be space delimited and contained within one string.
 
 At the time of authoring this documentation, the following scopes are available.
 

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -8,6 +8,7 @@ use League\OAuth2\Client\Token\AccessToken;
 class LinkedIn extends AbstractProvider
 {
     public $scopes = [];
+    public $scopeSeparator = ' ';
     public $responseType = 'json';
     public $authorizationHeader = 'Bearer';
     public $fields = [

--- a/test/src/Provider/LinkedInTest.php
+++ b/test/src/Provider/LinkedInTest.php
@@ -67,7 +67,12 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
 
     public function testScopes()
     {
-        $this->assertEquals([], $this->provider->getScopes());
+        $this->assertEmpty($this->provider->getScopes());
+
+        $this->provider->setScopes(['r_basicprofile','r_emailaddress']);
+        $authUrl = $this->provider->getAuthorizationUrl();
+
+        $this->assertContains('scope=r_basicprofile+r_emailaddress', $authUrl);
     }
 
     public function testUserData()


### PR DESCRIPTION
Related to issue #335 and #346 , the LinkedIn provider can support scopes as a complete array, instead of a single index with all scopes space delimited. 

This also includes a test to ensure the authorization url is formatted correctly. 

This change has already be made and published in the separate package.
