### PR TITLE
Use Guzzle/Service/Client get Method to Set Header

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -356,12 +356,7 @@ abstract class AbstractProvider implements ProviderInterface
         try {
             $client = $this->getHttpClient();
             $client->setBaseUrl($url);
-
-            if ($headers) {
-                $client->setDefaultOption('headers', $headers);
-            }
-
-            $request = $client->get()->send();
+            $request = $client->get(null, $headers)->send();
             $response = $request->getBody();
         } catch (BadResponseException $e) {
             // @codeCoverageIgnoreStart

--- a/test/src/Provider/EventbriteTest.php
+++ b/test/src/Provider/EventbriteTest.php
@@ -82,7 +82,6 @@ class EventbriteTest extends \PHPUnit_Framework_TestCase
         $client->shouldReceive('setBaseUrl')->times(5);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
-        $client->shouldReceive('setDefaultOption')->times(4);
         $this->provider->setHttpClient($client);
 
         $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);

--- a/test/src/Provider/GithubTest.php
+++ b/test/src/Provider/GithubTest.php
@@ -121,7 +121,6 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(5);
-        $client->shouldReceive('setDefaultOption')->times(4);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);
@@ -181,7 +180,6 @@ class GithubTest extends \PHPUnit_Framework_TestCase
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(2);
-        $client->shouldReceive('setDefaultOption')->times(1);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(1)->andReturn($getResponse);
         $this->provider->setHttpClient($client);

--- a/test/src/Provider/GoogleTest.php
+++ b/test/src/Provider/GoogleTest.php
@@ -84,7 +84,6 @@ class GoogleTest extends \PHPUnit_Framework_TestCase
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(5);
-        $client->shouldReceive('setDefaultOption')->times(4);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);

--- a/test/src/Provider/LinkedInTest.php
+++ b/test/src/Provider/LinkedInTest.php
@@ -80,7 +80,6 @@ class LinkedInTest extends \PHPUnit_Framework_TestCase
 
         $client = m::mock('Guzzle\Service\Client');
         $client->shouldReceive('setBaseUrl')->times(5);
-        $client->shouldReceive('setDefaultOption')->times(4);
         $client->shouldReceive('post->send')->times(1)->andReturn($postResponse);
         $client->shouldReceive('get->send')->times(4)->andReturn($getResponse);
         $this->provider->setHttpClient($client);


### PR DESCRIPTION
Remove calls to `setDefaultOption` to set the headers for the
get request being generated by the AbstractProvider. This change
was made to fix `Requires authentication` errors being recieved
from GitHub and `Unknown authentication scheme` errors being
recieved from LinkedIn.

Looking into the documentation on Guzzle the get method on the
client will manage and set our headers for us, and was used in
place of `setDefaultOption`.

Tests were updated to reflect the removal of the call to
`setDefaultOption`.