### PR TITLE
Pass ResponseInterface and parsed body to checkResponse

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -421,11 +421,9 @@ abstract class AbstractProvider
         $request  = $this->getAccessTokenRequest($params);
         $response = $this->getResponse($request);
 
-        $this->checkResponse($response);
+        $prepared = $this->prepareAccessTokenResponse($response);
 
-        $response = $this->prepareAccessTokenResponse($response);
-
-        return $grant->createAccessToken($response);
+        return $grant->createAccessToken($prepared);
     }
 
 
@@ -489,7 +487,11 @@ abstract class AbstractProvider
     public function getResponse(RequestInterface $request)
     {
         $response = $this->sendRequest($request);
-        return $this->parseResponse($response);
+        $parsed = $this->parseResponse($response);
+
+        $this->checkResponse($response, $parsed);
+
+        return $parsed;
     }
 
 
@@ -553,10 +555,11 @@ abstract class AbstractProvider
      * Check a provider response for errors.
      *
      * @throws IdentityProviderException
-     * @param  string $response
+     * @param  ResponseInterface $response
+     * @param  string $data Parsed response data
      * @return void
      */
-    abstract protected function checkResponse($response);
+    abstract protected function checkResponse(ResponseInterface $response, $data);
 
     /**
      * Prepare the access token response for the grant.

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -6,6 +6,7 @@ use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use Psr\Http\Message\ResponseInterface;
 
 class Fake extends AbstractProvider
 {
@@ -48,10 +49,10 @@ class Fake extends AbstractProvider
         return new Fake\User($response);
     }
 
-    protected function checkResponse($response)
+    protected function checkResponse(ResponseInterface $response, $data)
     {
-        if (!empty($response['error'])) {
-            throw new IdentityProviderException($response['error'], $response['code'], $response);
+        if (!empty($data['error'])) {
+            throw new IdentityProviderException($data['error'], $data['code'], $data);
         }
     }
 }


### PR DESCRIPTION
Attempt to fix #338.

The problem that this is trying to solve:

It is not possible to detect an error when a service uses status codes to indicate failure rather than the response body. Currently, checkResponse only accepts the parsed body, so this PR proposes to also use the `ResponseInterface` alongside the parsed body. This allows a provider to utilise the status code or other metadata on the response to determine whether an error has occurred. 

Note: I've also added `checkResponse` to `getResponse` - not sure if that's what we want though? Wasn't sure if `checkResponse` is an access token request thing only. 