### PR TITLE
Bringing test coverage up to 100%

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -108,11 +108,13 @@ class AccessToken
      */
     public function hasExpired()
     {
-        if (!isset($this->expires)) {
+        $expires = $this->getExpires();
+
+        if (empty($expires)) {
             throw new RuntimeException('"expires" is not set on the token');
         }
 
-        return $this->expires < time();
+        return $expires < time();
     }
 
     /**

--- a/src/Tool/MacAuthorizationTrait.php
+++ b/src/Tool/MacAuthorizationTrait.php
@@ -32,13 +32,20 @@ trait MacAuthorizationTrait
     // AbstractProvider
     abstract protected function getRandomState($length);
 
+    /**
+     * Get authorization headers
+     *
+     * @param  AccessToken $token
+     *
+     * @return array
+     * @codeCoverageIgnore
+     *
+     * @todo This is currently untested and provided only as an example. If you
+     * complete the implementation, please create a pull request for
+     * https://github.com/thephpleague/oauth2-client
+     */
     protected function getAuthorizationHeaders($token = null)
     {
-        // This is currently untested and provided only as an example. If you
-        // complete the implementation, please create a pull request for
-        // https://github.com/thephpleague/oauth2-client
-
-        // @codeCoverageIgnoreStart
         $ts    = time();
         $id    = $this->getTokenId($token);
         $nonce = $this->getRandomState(16);
@@ -50,6 +57,5 @@ trait MacAuthorizationTrait
         }
 
         return ['Authorization' => 'MAC ' . implode(",\n", $parts)];
-        // @codeCoverageIgnoreEnd
     }
 }

--- a/test/src/Provider/Fake/ProviderWithAccessTokenUid.php
+++ b/test/src/Provider/Fake/ProviderWithAccessTokenUid.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace League\OAuth2\Client\Test\Provider\Fake;
+
+use League\OAuth2\Client\Test\Provider\Fake as MockProvider;
+
+class ProviderWithAccessTokenUid extends MockProvider
+{
+    const ACCESS_TOKEN_UID = 'user_id';
+}

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -3,6 +3,7 @@
 namespace League\OAuth2\Client\Test\Token;
 
 use League\OAuth2\Client\Token\AccessToken;
+use Mockery as m;
 
 class AccessTokenTest extends \PHPUnit_Framework_TestCase
 {
@@ -11,18 +12,79 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidRefreshToken()
     {
-        $token = new AccessToken(['invalid_access_token' => 'none']);
+        $token = $this->getAccessToken(['invalid_access_token' => 'none']);
+    }
+
+    protected function getAccessToken($options = [])
+    {
+        return new AccessToken($options);
     }
 
     public function testExpiresInCorrection()
     {
         $options = ['access_token' => 'access_token', 'expires_in' => 100];
-        $token = new AccessToken($options);
+        $token = $this->getAccessToken($options);
 
         $expires = $token->getExpires();
 
         $this->assertNotNull($expires);
         $this->assertGreaterThan(time(), $expires);
         $this->assertLessThan(time() + 200, $expires);
+    }
+
+    public function testGetRefreshToken()
+    {
+        $options = [
+            'access_token' => 'access_token',
+            'refresh_token' => uniqid()
+        ];
+        $token = $this->getAccessToken($options);
+
+        $refreshToken = $token->getRefreshToken();
+
+        $this->assertEquals($options['refresh_token'], $refreshToken);
+    }
+
+    public function testHasNotExpiredWhenPropertySetInFuture()
+    {
+        $options = [
+            'access_token' => 'access_token'
+        ];
+
+        $expectedExpires = strtotime('+1 day');
+        $token = m::mock(AccessToken::class, [$options])->makePartial();
+        $token->shouldReceive('getExpires')->once()->andReturn($expectedExpires);
+
+        $hasExpired = $token->hasExpired();
+
+        $this->assertFalse($hasExpired);
+    }
+
+    public function testHasExpiredWhenPropertySetInPast()
+    {
+        $options = [
+            'access_token' => 'access_token'
+        ];
+
+        $expectedExpires = strtotime('-1 day');
+        $token = m::mock(AccessToken::class, [$options])->makePartial();
+        $token->shouldReceive('getExpires')->once()->andReturn($expectedExpires);
+
+        $hasExpired = $token->hasExpired();
+
+        $this->assertTrue($hasExpired);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testCannotReportExpiredWhenNoExpirationSet()
+    {
+        $options = [
+            'access_token' => 'access_token',
+        ];
+        $token = $this->getAccessToken($options);
+
+        $hasExpired = $token->hasExpired();
     }
 }


### PR DESCRIPTION
In response to #352, I humbly submit these changes.

There is definitely some room to refactor some of the implementations to improve testability, and I think it is in ok shape here. 

One thing I want to point out.

#### Added a new fake provider to test AbstractProvider constant
The `AbstractProvider` includes a `ACCESS_TOKEN_UID` constant set to null. In order to completely test the `prepareAccessTokenResponse` method, this constant needed to be set. The choice I was presented with was to set the `Fake` class constant to a value, which broken many existing tests, or create a new child class of `Fake` where the constant is set. I chose the latter.
