### PR TITLE
Remove newline in header since RFC 7230 deprecates multiline headers

### DIFF
--- a/src/Tool/MacAuthorizationTrait.php
+++ b/src/Tool/MacAuthorizationTrait.php
@@ -56,6 +56,6 @@ trait MacAuthorizationTrait
             $parts[] = sprintf('%s="%s"', $key, $value);
         }
 
-        return ['Authorization' => 'MAC ' . implode(",\n", $parts)];
+        return ['Authorization' => 'MAC ' . implode(', ', $parts)];
     }
 }


### PR DESCRIPTION
See: https://tools.ietf.org/html/rfc7230#section-3.2.4