### PR TITLE
Rename user methods to suggest what they do

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -599,13 +599,13 @@ abstract class AbstractProvider
      * @param AccessToken $token
      * @return League\OAuth2\Client\Provider\UserInterface
      */
-    abstract protected function prepareUserDetails(array $response, AccessToken $token);
+    abstract protected function createUser(array $response, AccessToken $token);
 
-    public function getUserDetails(AccessToken $token)
+    public function getUser(AccessToken $token)
     {
         $response = $this->fetchUserDetails($token);
 
-        return $this->prepareUserDetails($response, $token);
+        return $this->createUser($response, $token);
     }
 
     protected function fetchUserDetails(AccessToken $token)

--- a/src/Provider/StandardProvider.php
+++ b/src/Provider/StandardProvider.php
@@ -169,7 +169,7 @@ class StandardProvider extends AbstractProvider
         }
     }
 
-    protected function prepareUserDetails(array $response, AccessToken $token)
+    protected function createUser(array $response, AccessToken $token)
     {
         return new StandardUser($response, $this->responseUid);
     }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -178,7 +178,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $provider->setHttpClient($client);
 
-        $user = $provider->getUserDetails($token);
+        $user = $provider->getUser($token);
 
         $this->assertEquals($id, $user->getUserId());
         $this->assertEquals($name, $user->getUserScreenName());

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -44,7 +44,7 @@ class Fake extends AbstractProvider
         return $this->accessTokenMethod;
     }
 
-    protected function prepareUserDetails(array $response, AccessToken $token)
+    protected function createUser(array $response, AccessToken $token)
     {
         return new Fake\User($response);
     }

--- a/test/src/Provider/StandardProviderTest.php
+++ b/test/src/Provider/StandardProviderTest.php
@@ -96,7 +96,7 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
             'responseUid'    => 'mock_response_uid',
         ]);
 
-        $user = $provider->getUserDetails($token);
+        $user = $provider->getUser($token);
 
         $this->assertInstanceOf(StandardUser::class, $user);
         $this->assertSame(1, $user->getUserId());


### PR DESCRIPTION
`prepareUserDetails` -> `createUser` (protected), creates a `UserInterface` implementation
`getUserDetails` -> `getUser` (public), returns a `UserInterface` implementation