### PR TITLE
Pass AccessToken to getDefaultHeaders

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -656,7 +656,7 @@ abstract class AbstractProvider
      */
     public function getHeaders($token = null)
     {
-        $headers = $this->getDefaultHeaders();
+        $headers = $this->getDefaultHeaders($token);
         if ($token) {
             $headers = array_merge($headers, $this->getAuthorizationHeaders($token));
         }


### PR DESCRIPTION
I think this was a minor thing that was missed earlier. The Reddit provider relies on token access in `getDefaultHeaders`, but I *could* restructure to go without. The current method header for `getDefaultHeaders` does expect a token though, so I'm led to believe that this is the intended behaviour.