### PR TITLE
Remove Zend\Diactoros dev-dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
         "mockery/mockery": "~0.9",
         "squizlabs/php_codesniffer": "~2.0",
         "satooshi/php-coveralls": "0.6.*",
-        "jakub-onderka/php-parallel-lint": "0.8.*",
-        "zendframework/zend-diactoros": "^1.1"
+        "jakub-onderka/php-parallel-lint": "0.8.*"
     },
     "keywords": [
         "oauth",

--- a/test/src/Provider/StandardProviderTest.php
+++ b/test/src/Provider/StandardProviderTest.php
@@ -8,7 +8,6 @@ use League\OAuth2\Client\Provider\StandardUser;
 use League\OAuth2\Client\Token\AccessToken;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
-use Zend\Diactoros\Response\HtmlResponse;
 
 use Mockery as m;
 
@@ -111,7 +110,7 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testCheckResponse()
     {
-        $response = new HtmlResponse('foo');
+        $response = m::mock(ResponseInterface::class);
 
         $options = [
             'urlAuthorize'      => 'http://example.com/authorize',
@@ -134,7 +133,7 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCheckResponseThrowsException()
     {
-        $response = new HtmlResponse('foo');
+        $response = m::mock(ResponseInterface::class);
 
         $options = [
             'urlAuthorize'      => 'http://example.com/authorize',


### PR DESCRIPTION
I don't think we need this seeing as we already have Guzzle 6 as a dependency. I know it's just a dev-dependency but it's redundant nonetheless. 