### PR TITLE
Another proposed cleanup of getAccessToken

### DIFF
--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -375,7 +375,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $token = new AccessToken(['access_token' => 'abc', 'expires_in' => 3600]);
 
-        $request = $provider->getAuthenticatedRequest('get', 'https://api.example.com/v1/test', $token);
+        $request = $provider->getRequest('get', 'https://api.example.com/v1/test', $token);
         $this->assertInstanceOf(RequestInterface::class, $request);
 
         // Authorization header should contain the token
@@ -471,21 +471,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($raw_response['uid'], $token->getUid());
         $this->assertSame($raw_response['access_token'], $token->getToken());
         $this->assertSame($raw_response['expires'], $token->getExpires());
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testInvalidAccessTokenMethod()
-    {
-        $provider = new MockProvider([
-          'clientId' => 'mock_client_id',
-          'clientSecret' => 'mock_secret',
-          'redirectUri' => 'none',
-        ]);
-
-        $provider->setAccessTokenMethod('PUT');
-        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 
     private function getMethod($class, $name)


### PR DESCRIPTION
While updating the Reddit provider, I came across some cases where the current `getAccessToken` method is difficult to configure. I'll outline the changes here, but will comment inline with more detail.

- ~~Removed the request method constants.~~
- Removed `testInvalidAccessTokenMethod`
- Added `getAccessTokenUrl`
- Added `getAccessTokenHeaders`
- Added `getAccessTokenBody`
- Added `getAccessTokenOptions`
- ~~Fixed `prepareAccessTokenResponse` to also accept strings~~

- Removed `$token` parameter from `getDefaultHeaders`

These came up because:

1. I have to add a `Content-Type: application/x-www-form-urlencoded` header when requesting a Reddit access token.
2. I have to `urldecode` the request body because Reddit has a `grant_type` with forward slashes in it, which `http_build_query` automatically URL-encodes.
3. Reddit requires Basic HTTP auth when requesting an access token.