### PR TITLE
Proposed refactor of getRequest and getAccessToken

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -26,12 +26,12 @@ abstract class AbstractProvider
     /**
      * @var string HTTP method used to fetch access tokens.
      */
-    const ACCESS_TOKEN_METHOD_GET = 'GET';
+    const METHOD_GET = 'GET';
 
     /**
      * @var string HTTP method used to fetch access tokens.
      */
-    const ACCESS_TOKEN_METHOD_POST = 'POST';
+    const METHOD_POST = 'POST';
 
     /**
      * @var string
@@ -355,7 +355,7 @@ abstract class AbstractProvider
      */
     protected function getAccessTokenMethod()
     {
-        return self::ACCESS_TOKEN_METHOD_POST;
+        return self::METHOD_POST;
     }
 
     /**
@@ -387,32 +387,62 @@ abstract class AbstractProvider
     }
 
     /**
+     * Returns the full URL to use when requesting an access token.
+     *
+     * @param array $params Query parameters
+     */
+    protected function getAccessTokenUrl(array $params)
+    {
+        $url = $this->getBaseAccessTokenUrl();
+
+        if ($this->getAccessTokenMethod() === self::METHOD_GET) {
+            $query = $this->getAccessTokenQuery($params);
+            return $this->appendQuery($url, $query);
+        }
+
+        return $url;
+    }
+
+    /**
+     * Returns the request body for requesting an access token.
+     *
+     * @param  array $params
+     * @return string
+     */
+    protected function getAccessTokenBody(array $params)
+    {
+        return http_build_query($params);
+    }
+
+    /**
+     * Builds request options used for requesting an access token.
+     *
+     * @param  array $params
+     * @return array
+     */
+    protected function getAccessTokenOptions(array $params)
+    {
+        $options = [];
+
+        if ($this->getAccessTokenMethod() === self::METHOD_POST) {
+            $options['body'] = $this->getAccessTokenBody($params);
+        }
+
+        return $options;
+    }
+
+    /**
      * Returns a prepared request for requesting an access token.
      *
      * @param array $params Query string parameters
      */
     protected function getAccessTokenRequest(array $params)
     {
-        $url = $this->getBaseAccessTokenUrl();
-        $query = $this->getAccessTokenQuery($params);
-        $method = strtoupper($this->getAccessTokenMethod());
+        $method  = $this->getAccessTokenMethod();
+        $url     = $this->getAccessTokenUrl($params);
+        $options = $this->getAccessTokenOptions($params);
 
-        $options = [];
-
-        switch ($method) {
-            case 'GET':
-                $url = $this->appendQuery($url, $query);
-                break;
-            case 'POST':
-                $options['body'] = $query;
-                break;
-            default:
-                throw new InvalidArgumentException(
-                    "Unsupported access token request method: '$method'"
-                );
-        }
-
-        return $this->getRequest($method, $url, $options);
+        return $this->getRequest($method, $url, null, $options);
     }
 
     /**
@@ -434,7 +464,6 @@ abstract class AbstractProvider
         $params   = $grant->prepareRequestParameters($params, $options);
         $request  = $this->getAccessTokenRequest($params);
         $response = $this->getResponse($request);
-
         $prepared = $this->prepareAccessTokenResponse($response);
 
         return $grant->createAccessToken($prepared);
@@ -442,36 +471,25 @@ abstract class AbstractProvider
 
 
     /**
-     * Get a request instance.
+     * Get a request instance, optionally authenticated using an access token.
      *
      * Creates a PSR-7 compatible request instance that can be modified.
-     * The request is not automatically authenticated.
      *
      * @param  string $method
      * @param  string $url
+     * @param  AccessToken|string $token
      * @param  array  $options Any of "headers", "body", and "protocolVersion".
      * @return RequestInterface
      */
-    public function getRequest($method, $url, array $options = [])
+    public function getRequest($method, $url, $token = null, array $options = [])
     {
-        return $this->getRequestFactory()->getRequestWithOptions($method, $url, $options);
-    }
+        $options = array_merge_recursive($options, [
+            'headers' => $this->getHeaders($token),
+        ]);
 
-    /**
-     * Get an authenticated request instance.
-     *
-     * Creates a PSR-7 compatible request instance that can be modified.
-     *
-     * @param  string $method
-     * @param  string $url
-     * @param  AccessToken $token
-     * @param  array  $options Any of "headers", "body", and "protocolVersion".
-     * @return RequestInterface
-     */
-    public function getAuthenticatedRequest($method, $url, AccessToken $token, array $options = [])
-    {
-        $options['headers'] = $this->getHeaders($token);
-        return $this->getRequest($method, $url, $options);
+        $factory = $this->getRequestFactory();
+
+        return $factory->getRequestWithOptions($method, $url, $options);
     }
 
     /**
@@ -581,7 +599,7 @@ abstract class AbstractProvider
      * Custom mapping of expirations, etc should be done here. Always call the
      * parent method when overloading this method!
      *
-     * @param  array $result
+     * @param  mixed $result
      * @return array
      */
     protected function prepareAccessTokenResponse(array $result)
@@ -612,7 +630,7 @@ abstract class AbstractProvider
     {
         $url = $this->getUserDetailsUrl($token);
 
-        $request = $this->getAuthenticatedRequest('GET', $url, $token);
+        $request = $this->getRequest(self::METHOD_GET, $url, $token);
 
         return $this->getResponse($request);
     }
@@ -622,10 +640,9 @@ abstract class AbstractProvider
      *
      * Typically this is used to set Accept or Content-Type headers.
      *
-     * @param  AccessToken $token
      * @return array
      */
-    protected function getDefaultHeaders($token = null)
+    protected function getDefaultHeaders()
     {
         return [];
     }
@@ -656,7 +673,7 @@ abstract class AbstractProvider
      */
     public function getHeaders($token = null)
     {
-        $headers = $this->getDefaultHeaders($token);
+        $headers = $this->getDefaultHeaders();
         if ($token) {
             $headers = array_merge($headers, $this->getAuthorizationHeaders($token));
         }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -375,7 +375,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $token = new AccessToken(['access_token' => 'abc', 'expires_in' => 3600]);
 
-        $request = $provider->getAuthenticatedRequest('get', 'https://api.example.com/v1/test', $token);
+        $request = $provider->getRequest('get', 'https://api.example.com/v1/test', $token);
         $this->assertInstanceOf(RequestInterface::class, $request);
 
         // Authorization header should contain the token
@@ -471,21 +471,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($raw_response['uid'], $token->getUid());
         $this->assertSame($raw_response['access_token'], $token->getToken());
         $this->assertSame($raw_response['expires'], $token->getExpires());
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testInvalidAccessTokenMethod()
-    {
-        $provider = new MockProvider([
-          'clientId' => 'mock_client_id',
-          'clientSecret' => 'mock_secret',
-          'redirectUri' => 'none',
-        ]);
-
-        $provider->setAccessTokenMethod('PUT');
-        $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 
     private function getMethod($class, $name)

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -375,7 +375,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $token = new AccessToken(['access_token' => 'abc', 'expires_in' => 3600]);
 
-        $request = $provider->getRequest('get', 'https://api.example.com/v1/test', $token);
+        $request = $provider->getAuthenticatedRequest('get', 'https://api.example.com/v1/test', $token);
         $this->assertInstanceOf(RequestInterface::class, $request);
 
         // Authorization header should contain the token


### PR DESCRIPTION
This is a cleaner attempt at #363.

I'll outline the changes here and comment inline with more details.

---

- **Renamed** `ACCESS_TOKEN_METHOD_GET` -> `METHOD_GET`
- **Renamed** `ACCESS_TOKEN_METHOD_POST` -> `METHOD_POST`
- ~~**Removed** `getAuthenticatedRequest`~~ 
- **Removed** `$token` parameter from `getDefaultHeaders`
- **Removed** `testInvalidAccessTokenMethod`
- **Added** `createRequest`
- **Added** `getAccessTokenUrl`
- **Added** `getAccessTokenBody`
- **Added** `getAccessTokenOptions`
- ~~**Added** `$token` parameter to `getRequest`~~

---

These came up because you have to add a `Content-Type: application/x-www-form-urlencoded` header when requesting a Reddit access token.

You have to `urldecode` the request body because Reddit has a `grant_type` with forward slashes in it, which `http_build_query` automatically encodes and Reddit doesn't like it. I'm not sure if setting the urlencoded header fixes that.

Reddit requires Basic HTTP auth when requesting an access token, so should have access to headers.