### PR TITLE
Remove --prefer-source from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction
 
 script:
   - mkdir -p build/logs


### PR DESCRIPTION
> **--prefer-source**: There are two ways of downloading a package: `source` and `dist`. For stable versions Composer will use the `dist` by default. The `source` is a version control repository. If `--prefer-source` is enabled, Composer will install from `source` if there is one. This is useful if you want to make a bugfix to a project and get a local git clone of the dependency directly.

Travis CI clones the repository of every dependency every time. I think this is why our builds are timing out, and there is no reason why we need to be doing that.