### PR TITLE
Enhanced json_encode() serialization of AccessToken

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -15,9 +15,10 @@
 namespace League\OAuth2\Client\Token;
 
 use InvalidArgumentException;
+use JsonSerializable;
 use RuntimeException;
 
-class AccessToken
+class AccessToken implements JsonSerializable
 {
     /**
      * @var  string
@@ -137,5 +138,30 @@ class AccessToken
     public function __toString()
     {
         return (string) $this->getToken();
+    }
+
+    /**
+     * Returns an array of parameters to serialize when this is serialized with
+     * json_encode().
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        $parameters = [];
+
+        if ($this->accessToken) {
+            $parameters['access_token'] = $this->accessToken;
+        }
+
+        if ($this->refreshToken) {
+            $parameters['refresh_token'] = $this->refreshToken;
+        }
+
+        if ($this->expires) {
+            $parameters['expires_in'] = $this->expires - time();
+        }
+
+        return $parameters;
     }
 }

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -87,4 +87,18 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
 
         $hasExpired = $token->hasExpired();
     }
+
+    public function testJsonSerialzable()
+    {
+        $options = [
+            'access_token' => 'mock_access_token',
+            'refresh_token' => 'mock_refresh_token',
+            'expires_in' => 100,
+        ];
+
+        $token = $this->getAccessToken($options);
+        $jsonToken = json_encode($token);
+
+        $this->assertEquals($options, json_decode($jsonToken, true));
+    }
 }


### PR DESCRIPTION
Fixes #373

@shadowhand and @rtheunissen, please review and let me know if you think this is a good idea. I'm not sure I'm sold on it, but it definitely adds convenience for those using `json_encode()` on the `AccessToken` object.