### PR TITLE
Convert all uses of "user" to "resource owner"

### DIFF
--- a/README.PROVIDER-GUIDE.md
+++ b/README.PROVIDER-GUIDE.md
@@ -22,45 +22,48 @@ and implement the required abstract methods:
 ```php
 abstract public function getBaseAuthorizationUrl();
 abstract public function getBaseAccessTokenUrl(array $params);
-abstract public function getUserDetailsUrl(AccessToken $token);
+abstract public function getResourceOwnerDetailsUrl(AccessToken $token);
 abstract protected function getDefaultScopes();
 abstract protected function checkResponse(ResponseInterface $response, $data);
-abstract protected function createUser(array $response, AccessToken $token);
+abstract protected function createResourceOwner(array $response, AccessToken $token);
 ```
 
 Each of these abstract methods contain a docblock defining their expectations
 and typical behavior. Once you have extended this class, you can simply follow
 the [usage example in the README](README.md#usage) using your new `Provider`.
 
-### Account identifiers in access token responses
+### Resource owner identifiers in access token responses
 
-We have decided to abstract away as much of the user details as possible, since
-these are not part of the OAuth 2.0 specification and are very specific to each
+In services where the resource owner is a person, the resource owner is sometimes
+referred to as an end-user.
+
+We have decided to abstract away as much of the resource owner details as possible,
+since these are not part of the OAuth 2.0 specification and are very specific to each
 service provider. This provides greater flexibility to each provider, allowing
-them to handle the implementation details for service users.
+them to handle the implementation details for resource owners.
 
-The `AbstractProvider` does not specify an access token user identifier. It is
-the responsibility of the provider class to set the `ACCESS_TOKEN_UID` constant
+The `AbstractProvider` does not specify an access token resource owner identifier. It is
+the responsibility of the provider class to set the `ACCESS_TOKEN_OID` constant
 to the string value of the key used in the access token response to identify the
-user.
+resource owner.
 
 ```php
 /**
- * @var string Key used in the access token response to identify the user.
+ * @var string Key used in the access token response to identify the resource owner.
  */
-const ACCESS_TOKEN_UID = null;
+const ACCESS_TOKEN_OID = null;
 ```
 
 Once this is set on your provider, when calling `AbstractProvider::getAccessToken()`,
-the `AccessToken` returned will have its `$uid` property set, which you may
-retrieve by calling `AccessToken::getUid()`.
+the `AccessToken` returned will have its `$oid` property set, which you may
+retrieve by calling `AccessToken::getOid()`.
 
-The next step is to implement the `AbstractProvider::createUser()` method. This
+The next step is to implement the `AbstractProvider::createResourceOwner()` method. This
 method accepts as parameters a response array and an `AccessToken`. You may use
-this information in order to request user details from your service and
+this information in order to request resource owner details from your service and
 construct and return an object that implements
-[`League\OAuth2\Client\Provider\UserInterface`](src/Provider/UserInterface.php).
-This object is returned when calling `AbstractProvider::getUser()`.
+[`League\OAuth2\Client\Provider\ResourceOwnerInterface`](src/Provider/ResourceOwnerInterface.php).
+This object is returned when calling `AbstractProvider::getResourceOwner()`.
 
 ### Make your gateway official
 

--- a/README.PROVIDER-GUIDE.md
+++ b/README.PROVIDER-GUIDE.md
@@ -43,7 +43,7 @@ service provider. This provides greater flexibility to each provider, allowing
 them to handle the implementation details for resource owners.
 
 The `AbstractProvider` does not specify an access token resource owner identifier. It is
-the responsibility of the provider class to set the `ACCESS_TOKEN_OID` constant
+the responsibility of the provider class to set the `ACCESS_TOKEN_RESOURCE_OWNER_ID` constant
 to the string value of the key used in the access token response to identify the
 resource owner.
 
@@ -51,12 +51,12 @@ resource owner.
 /**
  * @var string Key used in the access token response to identify the resource owner.
  */
-const ACCESS_TOKEN_OID = null;
+const ACCESS_TOKEN_RESOURCE_OWNER_ID = null;
 ```
 
 Once this is set on your provider, when calling `AbstractProvider::getAccessToken()`,
-the `AccessToken` returned will have its `$oid` property set, which you may
-retrieve by calling `AccessToken::getOid()`.
+the `AccessToken` returned will have its `$resourceOwnerId` property set, which you may
+retrieve by calling `AccessToken::getResourceOwnerId()`.
 
 The next step is to implement the `AbstractProvider::createResourceOwner()` method. This
 method accepts as parameters a response array and an `AccessToken`. You may use

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ if (!isset($_GET['code'])) {
     try {
 
         // We got an access token, let's now get the user's details
-        $userDetails = $provider->getUserDetails($token);
+        $userDetails = $provider->getResourceOwner($token);
 
         // Use these details to create a new profile
         printf('Hello %s!', $userDetails->firstName);

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -31,9 +31,9 @@ use UnexpectedValueException;
 abstract class AbstractProvider
 {
     /**
-     * @var string Key used in the access token response to identify the user.
+     * @var string Key used in the access token response to identify the resource owner.
      */
-    const ACCESS_TOKEN_UID = null;
+    const ACCESS_TOKEN_OID = null;
 
     /**
      * @var string HTTP method used to fetch access tokens.
@@ -227,7 +227,7 @@ abstract class AbstractProvider
 
     abstract public function getBaseAuthorizationUrl();
     abstract public function getBaseAccessTokenUrl(array $params);
-    abstract public function getUserDetailsUrl(AccessToken $token);
+    abstract public function getResourceOwnerDetailsUrl(AccessToken $token);
 
     /**
      * Get a new random string to use for auth state.
@@ -368,6 +368,16 @@ abstract class AbstractProvider
     protected function getAccessTokenMethod()
     {
         return self::METHOD_POST;
+    }
+
+    /**
+     * Returns the key used in the access token response to identify the resource owner.
+     *
+     * @return string Resource owner identifier key
+     */
+    protected function getAccessTokenOid()
+    {
+        return static::ACCESS_TOKEN_OID;
     }
 
     /**
@@ -643,31 +653,31 @@ abstract class AbstractProvider
      */
     protected function prepareAccessTokenResponse(array $result)
     {
-        if (static::ACCESS_TOKEN_UID) {
-            $result['uid'] = $result[static::ACCESS_TOKEN_UID];
+        if ($this->getAccessTokenOid()) {
+            $result['oid'] = $result[$this->getAccessTokenOid()];
         }
         return $result;
     }
 
     /**
-     * Generate a user object from a successful user details request.
+     * Generate a resource owner object from a successful resource owner details request.
      *
      * @param object $response
      * @param AccessToken $token
-     * @return League\OAuth2\Client\Provider\UserInterface
+     * @return League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
-    abstract protected function createUser(array $response, AccessToken $token);
+    abstract protected function createResourceOwner(array $response, AccessToken $token);
 
-    public function getUser(AccessToken $token)
+    public function getResourceOwner(AccessToken $token)
     {
-        $response = $this->fetchUserDetails($token);
+        $response = $this->fetchResourceOwnerDetails($token);
 
-        return $this->createUser($response, $token);
+        return $this->createResourceOwner($response, $token);
     }
 
-    protected function fetchUserDetails(AccessToken $token)
+    protected function fetchResourceOwnerDetails(AccessToken $token)
     {
-        $url = $this->getUserDetailsUrl($token);
+        $url = $this->getResourceOwnerDetailsUrl($token);
 
         $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);
 

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -33,7 +33,7 @@ abstract class AbstractProvider
     /**
      * @var string Key used in the access token response to identify the resource owner.
      */
-    const ACCESS_TOKEN_OID = null;
+    const ACCESS_TOKEN_RESOURCE_OWNER_ID = null;
 
     /**
      * @var string HTTP method used to fetch access tokens.
@@ -375,9 +375,9 @@ abstract class AbstractProvider
      *
      * @return string Resource owner identifier key
      */
-    protected function getAccessTokenOid()
+    protected function getAccessTokenResourceOwnerId()
     {
-        return static::ACCESS_TOKEN_OID;
+        return static::ACCESS_TOKEN_RESOURCE_OWNER_ID;
     }
 
     /**
@@ -653,8 +653,8 @@ abstract class AbstractProvider
      */
     protected function prepareAccessTokenResponse(array $result)
     {
-        if ($this->getAccessTokenOid()) {
-            $result['oid'] = $result[$this->getAccessTokenOid()];
+        if ($this->getAccessTokenResourceOwnerId()) {
+            $result['resource_owner_id'] = $result[$this->getAccessTokenResourceOwnerId()];
         }
         return $result;
     }

--- a/src/Provider/ResourceOwnerInterface.php
+++ b/src/Provider/ResourceOwnerInterface.php
@@ -14,36 +14,12 @@
 
 namespace League\OAuth2\Client\Provider;
 
-class StandardUser implements UserInterface
+interface ResourceOwnerInterface
 {
     /**
-     * @var array
-     */
-    protected $response;
-
-    /**
-     * @var string
-     */
-    protected $uid;
-
-    public function __construct(array $response, $uid)
-    {
-        $this->response = $response;
-        $this->uid = $uid;
-    }
-
-    public function getUserId()
-    {
-        return $this->response[$this->uid];
-    }
-
-    /**
-     * Get the raw user response.
+     * Get the identifier of the authorized resource owner.
      *
-     * @return array
+     * @return mixed
      */
-    public function toArray()
-    {
-        return $this->response;
-    }
+    public function getId();
 }

--- a/src/Provider/StandardProvider.php
+++ b/src/Provider/StandardProvider.php
@@ -44,7 +44,7 @@ class StandardProvider extends AbstractProvider
     /**
      * @var string
      */
-    private $accessTokenOid;
+    private $accessTokenResourceOwnerId;
 
     /**
      * @var array|null
@@ -69,7 +69,7 @@ class StandardProvider extends AbstractProvider
     /**
      * @var string
      */
-    private $responseOid = 'id';
+    private $responseResourceOwnerId = 'id';
 
     public function __construct($options = [], array $collaborators = [])
     {
@@ -97,11 +97,11 @@ class StandardProvider extends AbstractProvider
     {
         return array_merge($this->getRequiredOptions(), [
             'accessTokenMethod',
-            'accessTokenOid',
+            'accessTokenResourceOwnerId',
             'scopeSeparator',
             'responseError',
             'responseCode',
-            'responseOid',
+            'responseResourceOwnerId',
             'scopes',
         ]);
     }
@@ -162,9 +162,9 @@ class StandardProvider extends AbstractProvider
         return $this->accessTokenMethod ?: parent::getAccessTokenMethod();
     }
 
-    protected function getAccessTokenOid()
+    protected function getAccessTokenResourceOwnerId()
     {
-        return $this->accessTokenOid ?: parent::getAccessTokenOid();
+        return $this->accessTokenResourceOwnerId ?: parent::getAccessTokenResourceOwnerId();
     }
 
     protected function getScopeSeparator()
@@ -183,6 +183,6 @@ class StandardProvider extends AbstractProvider
 
     protected function createResourceOwner(array $response, AccessToken $token)
     {
-        return new StandardResourceOwner($response, $this->responseOid);
+        return new StandardResourceOwner($response, $this->responseResourceOwnerId);
     }
 }

--- a/src/Provider/StandardProvider.php
+++ b/src/Provider/StandardProvider.php
@@ -34,7 +34,7 @@ class StandardProvider extends AbstractProvider
     /**
      * @var string
      */
-    private $urlUserDetails;
+    private $urlResourceOwnerDetails;
 
     /**
      * @var string
@@ -44,7 +44,7 @@ class StandardProvider extends AbstractProvider
     /**
      * @var string
      */
-    private $accessTokenUid;
+    private $accessTokenOid;
 
     /**
      * @var array|null
@@ -69,7 +69,7 @@ class StandardProvider extends AbstractProvider
     /**
      * @var string
      */
-    private $responseUid = 'id';
+    private $responseOid = 'id';
 
     public function __construct($options = [], array $collaborators = [])
     {
@@ -97,11 +97,11 @@ class StandardProvider extends AbstractProvider
     {
         return array_merge($this->getRequiredOptions(), [
             'accessTokenMethod',
-            'accessTokenUid',
+            'accessTokenOid',
             'scopeSeparator',
             'responseError',
             'responseCode',
-            'responseUid',
+            'responseOid',
             'scopes',
         ]);
     }
@@ -116,7 +116,7 @@ class StandardProvider extends AbstractProvider
         return [
             'urlAuthorize',
             'urlAccessToken',
-            'urlUserDetails',
+            'urlResourceOwnerDetails',
         ];
     }
 
@@ -147,9 +147,9 @@ class StandardProvider extends AbstractProvider
         return $this->urlAccessToken;
     }
 
-    public function getUserDetailsUrl(AccessToken $token)
+    public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return $this->urlUserDetails;
+        return $this->urlResourceOwnerDetails;
     }
 
     public function getDefaultScopes()
@@ -162,9 +162,9 @@ class StandardProvider extends AbstractProvider
         return $this->accessTokenMethod ?: parent::getAccessTokenMethod();
     }
 
-    protected function getAccessTokenUid()
+    protected function getAccessTokenOid()
     {
-        return $this->accessTokenUid ?: parent::getAccessTokenUid();
+        return $this->accessTokenOid ?: parent::getAccessTokenOid();
     }
 
     protected function getScopeSeparator()
@@ -181,8 +181,8 @@ class StandardProvider extends AbstractProvider
         }
     }
 
-    protected function createUser(array $response, AccessToken $token)
+    protected function createResourceOwner(array $response, AccessToken $token)
     {
-        return new StandardUser($response, $this->responseUid);
+        return new StandardResourceOwner($response, $this->responseOid);
     }
 }

--- a/src/Provider/StandardResourceOwner.php
+++ b/src/Provider/StandardResourceOwner.php
@@ -24,17 +24,17 @@ class StandardResourceOwner implements ResourceOwnerInterface
     /**
      * @var string
      */
-    protected $oid;
+    protected $resourceOwnerId;
 
-    public function __construct(array $response, $oid)
+    public function __construct(array $response, $resourceOwnerId)
     {
         $this->response = $response;
-        $this->oid = $oid;
+        $this->resourceOwnerId = $resourceOwnerId;
     }
 
     public function getId()
     {
-        return $this->response[$this->oid];
+        return $this->response[$this->resourceOwnerId];
     }
 
     /**

--- a/src/Provider/StandardResourceOwner.php
+++ b/src/Provider/StandardResourceOwner.php
@@ -14,12 +14,36 @@
 
 namespace League\OAuth2\Client\Provider;
 
-interface UserInterface
+class StandardResourceOwner implements ResourceOwnerInterface
 {
     /**
-     * Get the identifier of the authorized user.
-     *
-     * @return mixed
+     * @var array
      */
-    public function getUserId();
+    protected $response;
+
+    /**
+     * @var string
+     */
+    protected $oid;
+
+    public function __construct(array $response, $oid)
+    {
+        $this->response = $response;
+        $this->oid = $oid;
+    }
+
+    public function getId()
+    {
+        return $this->response[$this->oid];
+    }
+
+    /**
+     * Get the raw resource owner response.
+     *
+     * @return array
+     */
+    public function toArray()
+    {
+        return $this->response;
+    }
 }

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -38,7 +38,7 @@ class AccessToken implements JsonSerializable
     /**
      * @var  string
      */
-    protected $uid;
+    protected $oid;
 
     /**
      * @param array $options
@@ -51,8 +51,8 @@ class AccessToken implements JsonSerializable
 
         $this->accessToken = $options['access_token'];
 
-        if (!empty($options['uid'])) {
-            $this->uid = $options['uid'];
+        if (!empty($options['oid'])) {
+            $this->oid = $options['oid'];
         }
 
         if (!empty($options['refresh_token'])) {
@@ -104,13 +104,13 @@ class AccessToken implements JsonSerializable
     }
 
     /**
-     * Get the user identifier, if defined.
+     * Get the resource owner identifier, if defined.
      *
      * @return string|null
      */
-    public function getUid()
+    public function getOid()
     {
-        return $this->uid;
+        return $this->oid;
     }
 
     /**

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -38,7 +38,7 @@ class AccessToken implements JsonSerializable
     /**
      * @var  string
      */
-    protected $oid;
+    protected $resourceOwnerId;
 
     /**
      * @param array $options
@@ -51,8 +51,8 @@ class AccessToken implements JsonSerializable
 
         $this->accessToken = $options['access_token'];
 
-        if (!empty($options['oid'])) {
-            $this->oid = $options['oid'];
+        if (!empty($options['resource_owner_id'])) {
+            $this->resourceOwnerId = $options['resource_owner_id'];
         }
 
         if (!empty($options['refresh_token'])) {
@@ -108,9 +108,9 @@ class AccessToken implements JsonSerializable
      *
      * @return string|null
      */
-    public function getOid()
+    public function getResourceOwnerId()
     {
-        return $this->oid;
+        return $this->resourceOwnerId;
     }
 
     /**

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -165,7 +165,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response->shouldReceive('getBody')->times(1)->andReturn($stream);
         $response->shouldReceive('getHeader')->with('content-type')->times(1)->andReturn('application/json');
 
-        $url = $provider->getUserDetailsUrl($token);
+        $url = $provider->getResourceOwnerDetailsUrl($token);
 
         $client = m::mock(ClientInterface::class);
         $client->shouldReceive('send')->with(
@@ -178,9 +178,9 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $provider->setHttpClient($client);
 
-        $user = $provider->getUser($token);
+        $user = $provider->getResourceOwner($token);
 
-        $this->assertEquals($id, $user->getUserId());
+        $this->assertEquals($id, $user->getId());
         $this->assertEquals($name, $user->getUserScreenName());
         $this->assertEquals($email, $user->getUserEmail());
     }
@@ -423,7 +423,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $provider->setAccessTokenMethod($method);
 
         $grant_name = 'mock';
-        $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'uid' => 3];
+        $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'oid' => 3];
         $token = new AccessToken($raw_response);
 
         $grant = m::mock(AbstractGrant::class);
@@ -468,7 +468,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $result = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code']);
 
         $this->assertSame($result, $token);
-        $this->assertSame($raw_response['uid'], $token->getUid());
+        $this->assertSame($raw_response['oid'], $token->getOid());
         $this->assertSame($raw_response['access_token'], $token->getToken());
         $this->assertSame($raw_response['expires'], $token->getExpires());
     }
@@ -556,13 +556,13 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultPrepareAccessTokenResponse()
     {
-        $provider = m::mock(Fake\ProviderWithAccessTokenUid::class);
+        $provider = m::mock(Fake\ProviderWithAccessTokenOid::class);
         $result = ['user_id' => uniqid()];
 
         $newResult = $provider->prepareAccessTokenResponse($result);
 
-        $this->assertTrue(isset($newResult['uid']));
-        $this->assertEquals($result['user_id'], $newResult['uid']);
+        $this->assertTrue(isset($newResult['oid']));
+        $this->assertEquals($result['user_id'], $newResult['oid']);
     }
 
     public function testDefaultAuthorizationHeaders()

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -423,7 +423,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $provider->setAccessTokenMethod($method);
 
         $grant_name = 'mock';
-        $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'oid' => 3];
+        $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'resource_owner_id' => 3];
         $token = new AccessToken($raw_response);
 
         $grant = m::mock(AbstractGrant::class);
@@ -468,7 +468,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $result = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code']);
 
         $this->assertSame($result, $token);
-        $this->assertSame($raw_response['oid'], $token->getOid());
+        $this->assertSame($raw_response['resource_owner_id'], $token->getResourceOwnerId());
         $this->assertSame($raw_response['access_token'], $token->getToken());
         $this->assertSame($raw_response['expires'], $token->getExpires());
     }
@@ -556,13 +556,13 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultPrepareAccessTokenResponse()
     {
-        $provider = m::mock(Fake\ProviderWithAccessTokenOid::class);
+        $provider = m::mock(Fake\ProviderWithAccessTokenResourceOwnerId::class);
         $result = ['user_id' => uniqid()];
 
         $newResult = $provider->prepareAccessTokenResponse($result);
 
-        $this->assertTrue(isset($newResult['oid']));
-        $this->assertEquals($result['user_id'], $newResult['oid']);
+        $this->assertTrue(isset($newResult['resource_owner_id']));
+        $this->assertEquals($result['user_id'], $newResult['resource_owner_id']);
     }
 
     public function testDefaultAuthorizationHeaders()

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -24,7 +24,7 @@ class Fake extends AbstractProvider
         return 'http://example.com/oauth/token';
     }
 
-    public function getUserDetailsUrl(AccessToken $token)
+    public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
         return 'http://example.com/oauth/user';
     }
@@ -44,7 +44,7 @@ class Fake extends AbstractProvider
         return $this->accessTokenMethod;
     }
 
-    protected function createUser(array $response, AccessToken $token)
+    protected function createResourceOwner(array $response, AccessToken $token)
     {
         return new Fake\User($response);
     }

--- a/test/src/Provider/Fake/ProviderWithAccessTokenOid.php
+++ b/test/src/Provider/Fake/ProviderWithAccessTokenOid.php
@@ -4,7 +4,7 @@ namespace League\OAuth2\Client\Test\Provider\Fake;
 
 use League\OAuth2\Client\Test\Provider\Fake as MockProvider;
 
-class ProviderWithAccessTokenUid extends MockProvider
+class ProviderWithAccessTokenOid extends MockProvider
 {
-    const ACCESS_TOKEN_UID = 'user_id';
+    const ACCESS_TOKEN_OID = 'user_id';
 }

--- a/test/src/Provider/Fake/ProviderWithAccessTokenResourceOwnerId.php
+++ b/test/src/Provider/Fake/ProviderWithAccessTokenResourceOwnerId.php
@@ -4,7 +4,7 @@ namespace League\OAuth2\Client\Test\Provider\Fake;
 
 use League\OAuth2\Client\Test\Provider\Fake as MockProvider;
 
-class ProviderWithAccessTokenOid extends MockProvider
+class ProviderWithAccessTokenResourceOwnerId extends MockProvider
 {
-    const ACCESS_TOKEN_OID = 'user_id';
+    const ACCESS_TOKEN_RESOURCE_OWNER_ID = 'user_id';
 }

--- a/test/src/Provider/Fake/User.php
+++ b/test/src/Provider/Fake/User.php
@@ -2,9 +2,9 @@
 
 namespace League\OAuth2\Client\Test\Provider\Fake;
 
-use League\OAuth2\Client\Provider\UserInterface;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 
-class User implements UserInterface
+class User implements ResourceOwnerInterface
 {
     /**
      * @var array
@@ -16,7 +16,7 @@ class User implements UserInterface
         $this->response = $response;
     }
 
-    public function getUserId()
+    public function getId()
     {
         return $this->response['id'];
     }

--- a/test/src/Provider/Standard.php
+++ b/test/src/Provider/Standard.php
@@ -21,7 +21,7 @@ class Standard extends StandardProvider
         parent::__construct($options);
     }
 
-    protected function fetchUserDetails(AccessToken $token)
+    protected function fetchResourceOwnerDetails(AccessToken $token)
     {
         return [
             'mock_response_uid' => 1,

--- a/test/src/Provider/StandardProviderTest.php
+++ b/test/src/Provider/StandardProviderTest.php
@@ -4,7 +4,7 @@ namespace League\OAuth2\Client\Test\Provider;
 
 use League\OAuth2\Client\Test\Provider\Standard as MockProvider;
 use League\OAuth2\Client\Provider\StandardProvider;
-use League\OAuth2\Client\Provider\StandardUser;
+use League\OAuth2\Client\Provider\StandardResourceOwner;
 use League\OAuth2\Client\Token\AccessToken;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -19,7 +19,7 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
         $required = [
             'urlAuthorize'   => 'http://example.com/authorize',
             'urlAccessToken' => 'http://example.com/token',
-            'urlUserDetails' => 'http://example.com/user',
+            'urlResourceOwnerDetails' => 'http://example.com/user',
         ];
 
         foreach ($required as $key => $value) {
@@ -44,13 +44,13 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
         $options = [
             'urlAuthorize'      => 'http://example.com/authorize',
             'urlAccessToken'    => 'http://example.com/token',
-            'urlUserDetails'    => 'http://example.com/user',
+            'urlResourceOwnerDetails' => 'http://example.com/user',
             'accessTokenMethod' => 'mock_method',
-            'accessTokenUid'    => 'mock_token_uid',
+            'accessTokenOid'    => 'mock_token_uid',
             'scopeSeparator'    => 'mock_separator',
             'responseError'     => 'mock_error',
             'responseCode'      => 'mock_code',
-            'responseUid'       => 'mock_response_uid',
+            'responseOid'       => 'mock_response_uid',
             'scopes'            => ['mock', 'scopes'],
         ];
 
@@ -66,7 +66,7 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($options['urlAuthorize'], $provider->getBaseAuthorizationUrl());
         $this->assertEquals($options['urlAccessToken'], $provider->getBaseAccessTokenUrl([]));
-        $this->assertEquals($options['urlUserDetails'], $provider->getUserDetailsUrl(new AccessToken(['access_token' => '1234'])));
+        $this->assertEquals($options['urlResourceOwnerDetails'], $provider->getResourceOwnerDetailsUrl(new AccessToken(['access_token' => '1234'])));
         $this->assertEquals($options['scopes'], $provider->getDefaultScopes());
 
         $reflection = new \ReflectionClass(get_class($provider));
@@ -75,30 +75,30 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
         $getAccessTokenMethod->setAccessible(true);
         $this->assertEquals($options['accessTokenMethod'], $getAccessTokenMethod->invoke($provider));
 
-        $getAccessTokenUid = $reflection->getMethod('getAccessTokenUid');
-        $getAccessTokenUid->setAccessible(true);
-        $this->assertEquals($options['accessTokenUid'], $getAccessTokenUid->invoke($provider));
+        $getAccessTokenOid = $reflection->getMethod('getAccessTokenOid');
+        $getAccessTokenOid->setAccessible(true);
+        $this->assertEquals($options['accessTokenOid'], $getAccessTokenOid->invoke($provider));
 
         $getScopeSeparator = $reflection->getMethod('getScopeSeparator');
         $getScopeSeparator->setAccessible(true);
         $this->assertEquals($options['scopeSeparator'], $getScopeSeparator->invoke($provider));
     }
 
-    public function testUserDetails()
+    public function testResourceOwnerDetails()
     {
         $token = new AccessToken(['access_token' => 'mock_token']);
 
         $provider = new MockProvider([
             'urlAuthorize'   => 'http://example.com/authorize',
             'urlAccessToken' => 'http://example.com/token',
-            'urlUserDetails' => 'http://example.com/user',
-            'responseUid'    => 'mock_response_uid',
+            'urlResourceOwnerDetails' => 'http://example.com/user',
+            'responseOid'    => 'mock_response_uid',
         ]);
 
-        $user = $provider->getUser($token);
+        $user = $provider->getResourceOwner($token);
 
-        $this->assertInstanceOf(StandardUser::class, $user);
-        $this->assertSame(1, $user->getUserId());
+        $this->assertInstanceOf(StandardResourceOwner::class, $user);
+        $this->assertSame(1, $user->getId());
 
         $data = $user->toArray();
 
@@ -115,7 +115,7 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
         $options = [
             'urlAuthorize'      => 'http://example.com/authorize',
             'urlAccessToken'    => 'http://example.com/token',
-            'urlUserDetails'    => 'http://example.com/user',
+            'urlResourceOwnerDetails' => 'http://example.com/user',
         ];
 
         $provider = new StandardProvider($options);
@@ -138,7 +138,7 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
         $options = [
             'urlAuthorize'      => 'http://example.com/authorize',
             'urlAccessToken'    => 'http://example.com/token',
-            'urlUserDetails'    => 'http://example.com/user',
+            'urlResourceOwnerDetails' => 'http://example.com/user',
         ];
 
         $provider = new StandardProvider($options);

--- a/test/src/Provider/StandardProviderTest.php
+++ b/test/src/Provider/StandardProviderTest.php
@@ -46,11 +46,11 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
             'urlAccessToken'    => 'http://example.com/token',
             'urlResourceOwnerDetails' => 'http://example.com/user',
             'accessTokenMethod' => 'mock_method',
-            'accessTokenOid'    => 'mock_token_uid',
+            'accessTokenResourceOwnerId' => 'mock_token_uid',
             'scopeSeparator'    => 'mock_separator',
             'responseError'     => 'mock_error',
             'responseCode'      => 'mock_code',
-            'responseOid'       => 'mock_response_uid',
+            'responseResourceOwnerId' => 'mock_response_uid',
             'scopes'            => ['mock', 'scopes'],
         ];
 
@@ -75,9 +75,9 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
         $getAccessTokenMethod->setAccessible(true);
         $this->assertEquals($options['accessTokenMethod'], $getAccessTokenMethod->invoke($provider));
 
-        $getAccessTokenOid = $reflection->getMethod('getAccessTokenOid');
-        $getAccessTokenOid->setAccessible(true);
-        $this->assertEquals($options['accessTokenOid'], $getAccessTokenOid->invoke($provider));
+        $getAccessTokenResourceOwnerId = $reflection->getMethod('getAccessTokenResourceOwnerId');
+        $getAccessTokenResourceOwnerId->setAccessible(true);
+        $this->assertEquals($options['accessTokenResourceOwnerId'], $getAccessTokenResourceOwnerId->invoke($provider));
 
         $getScopeSeparator = $reflection->getMethod('getScopeSeparator');
         $getScopeSeparator->setAccessible(true);
@@ -92,7 +92,7 @@ class StandardProviderTest extends \PHPUnit_Framework_TestCase
             'urlAuthorize'   => 'http://example.com/authorize',
             'urlAccessToken' => 'http://example.com/token',
             'urlResourceOwnerDetails' => 'http://example.com/user',
-            'responseOid'    => 'mock_response_uid',
+            'responseResourceOwnerId' => 'mock_response_uid',
         ]);
 
         $user = $provider->getResourceOwner($token);


### PR DESCRIPTION
This is an exploratory change to get feedback from the oauth2-client community. It is the result of a conversation on Twitter with @neilcrookes: https://twitter.com/ramsey/status/618437720554143744

I have never been comfortable providing any entity that represents a user, since the OAuth 2.0 specification does not specify anything to do with users. However, the specification does talk about resource owners, which may be end-users, if the resource owner is a person (see [section 1.1 of the OAuth 2.0 spec](http://tools.ietf.org/html/rfc6749#section-1.1)), but it may not be a user at all, as is the case with @neilcrookes's use-case.

With this change, the concept of the "user" is migrated to that of a "resource owner." Individual providers may call their class implementing the new `ResourceOwnerInterface` a User, if the resource owner in their service is a person, or they may call it something else entirely.

Here is exactly what has changed:

Used to be | Changed to
---------- | ----------
`AbstractProvider::ACCESS_TOKEN_UID` | `AbstractProvider::ACCESS_TOKEN_RESOURCE_OWNER_ID`
`AbstractProvider::getUserDetailsUrl()` | `AbstractProvider::getResourceOwnerDetailsUrl()`
`AbstractProvider::createUser()` | `AbstractProvider::createResourceOwner()`
`AbstractProvider::getUser()` | `AbstractProvider::getResourceOwner()`
`AbstractProvider::fetchUserDetails()` | `AbstractProvider::fetchResourceOwnerDetails()`
`UserInterface` | `ResourceOwnerInterface`
`UserInterface::getUserId()` | `ResourceOwnerInterface::getId()`
`StandardUser` | `StandardResourceOwner`
`AccessToken::getUid()` | `AccessToken::getResourceOwnerId()`

To summarize, I changed "User" to "ResourceOwner", "UID" to "RESOURCE_OWNER_ID", "Uid" to "ResourceOwnerId", and "uid" to "resource_owner_id". I have updated all the tests, and everything passes, with 100% code coverage.

Additionally, I added the `AbstractProvider::getAccessTokenResourceOwnerId()` method. I noticed that this was being called in the `StandardProvider`, though the method was not defined anywhere.