### PR TITLE
Move access token creation to AbstractProvider

### DIFF
--- a/src/Grant/AbstractGrant.php
+++ b/src/Grant/AbstractGrant.php
@@ -46,18 +46,6 @@ abstract class AbstractGrant
     }
 
     /**
-     * Converts the result from a response into an `AccessToken`.
-     *
-     * @param array $response
-     *
-     * @return AccessToken
-     */
-    public function createAccessToken(array $response)
-    {
-        return new AccessToken($response);
-    }
-
-    /**
      * Prepares an access token request's parameters by checking that all
      * required parameters are set, then merging with any given defaults.
      *

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -19,6 +19,7 @@ use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\ClientInterface as HttpClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
 use InvalidArgumentException;
+use League\OAuth2\Client\Grant\AbstractGrant;
 use League\OAuth2\Client\Grant\GrantFactory;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
@@ -472,6 +473,7 @@ abstract class AbstractProvider
      *
      * @param mixed $grant
      * @param array $options
+     * @return AccessToken
      */
     public function getAccessToken($grant, array $options = [])
     {
@@ -487,8 +489,9 @@ abstract class AbstractProvider
         $request  = $this->getAccessTokenRequest($params);
         $response = $this->getResponse($request);
         $prepared = $this->prepareAccessTokenResponse($response);
+        $token    = $this->createAccessToken($prepared, $grant);
 
-        return $grant->createAccessToken($prepared);
+        return $token;
     }
 
 
@@ -657,6 +660,21 @@ abstract class AbstractProvider
             $result['resource_owner_id'] = $result[$this->getAccessTokenResourceOwnerId()];
         }
         return $result;
+    }
+
+    /**
+     * Creates an access token from a response.
+     *
+     * The grant that was used to fetch the response can be used to provide
+     * additional context.
+     *
+     * @param array $response
+     * @param AbstractGrant $grant
+     * @return AccessToken
+     */
+    protected function createAccessToken(array $response, AbstractGrant $grant)
+    {
+        return new AccessToken($response);
     }
 
     /**

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -424,7 +424,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $grant_name = 'mock';
         $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'resource_owner_id' => 3];
-        $token = new AccessToken($raw_response);
 
         $grant = m::mock(AbstractGrant::class);
         $grant->shouldAllowMockingProtectedMethods();
@@ -438,10 +437,6 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
                   m::type('array')
               )
               ->andReturn([]);
-
-        $grant->shouldReceive('createAccessToken')
-              ->with($raw_response)
-              ->andReturn($token);
 
         $stream = m::mock(StreamInterface::class);
         $stream->shouldReceive('__toString')->times(1)->andReturn(
@@ -465,9 +460,9 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $provider->setHttpClient($client);
 
-        $result = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code']);
+        $token = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code']);
 
-        $this->assertSame($result, $token);
+        $this->assertInstanceOf(AccessToken::class, $token);
         $this->assertSame($raw_response['resource_owner_id'], $token->getResourceOwnerId());
         $this->assertSame($raw_response['access_token'], $token->getToken());
         $this->assertSame($raw_response['expires'], $token->getExpires());


### PR DESCRIPTION
Allows providers to modify access tokens without having to use custom grants.

Fixes #377