### PR TITLE
Storing the Provider Response in a class attribute

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -35,6 +35,8 @@ abstract class AbstractProvider implements ProviderInterface
 
     public $authorizationHeader;
 
+    public $providerResponse;
+    
     /**
      * @var GuzzleClient
      */

--- a/src/Provider/LinkedIn.php
+++ b/src/Provider/LinkedIn.php
@@ -34,6 +34,8 @@ class LinkedIn extends AbstractProvider
 
     public function userDetails($response, AccessToken $token)
     {
+        $this->providerResponse=$response;
+
         $user = new User();
 
         $email = (isset($response->emailAddress)) ? $response->emailAddress : null;


### PR DESCRIPTION
Would like to propose storing the response in a class attribute, so
that if we configure the OAuth to get additional information than the
User Object has, then this attribute can be used to get that
information. For instance I was trying to get “summary” and “Positions”
fields from LinkedIn, I am able to set $fields to include that in the
call to linked in but the return object only returns the User object
and that does not have all the fields. So providing a way to access the
actual response received would be good so that users can use this
extended information.

I am using something like this

        $oaFields = ['id', 'email-address', 'first-name', 'last-name', 'headline',
        'location', 'industry', 'picture-url', 'public-profile-url','summary','specialties','positions'];

        $this->_provider = new \League\OAuth2\Client\Provider\LinkedIn([
            'clientId' => $clientId,
            'clientSecret' => $clientSecret,
            'redirectUri' => $this->_app->site->uri['public'] . "/oauth/linkedin/$callback_page",
            'scopes' => $scopes]);
        $this->_provider->fields=$oaFields;

So even though the fetchUserDetails gets all the data from LinkedIn the User object does not pass all this back. 