### PR TITLE
Alternative solution to set access token request headers

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -445,7 +445,9 @@ abstract class AbstractProvider
      */
     protected function getAccessTokenOptions(array $params)
     {
-        $options = [];
+        $options = [
+          'headers' => $this->getAccessTokenRequestHeaders($params),
+        ];
 
         if ($this->getAccessTokenMethod() === self::METHOD_POST) {
             $options['body'] = $this->getAccessTokenBody($params);
@@ -700,6 +702,17 @@ abstract class AbstractProvider
         $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);
 
         return $this->getResponse($request);
+    }
+
+    /**
+     * Returns the headers used when requesting an access token.
+     *
+     * @param  array $params
+     * @return array
+     */
+    protected function getAccessTokenRequestHeaders(array $params)
+    {
+        return [];
     }
 
     /**

--- a/src/Tool/UrlEncodedRequestTrait.php
+++ b/src/Tool/UrlEncodedRequestTrait.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of the league/oauth2-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Alex Bilbie <hello@alexbilbie.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth2-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth2-client Packagist
+ * @link https://github.com/thephpleague/oauth2-client GitHub
+ */
+
+namespace League\OAuth2\Client\Tool;
+
+/**
+ *
+ */
+trait UrlEncodedRequestTrait
+{
+    protected function getAccessTokenRequestHeaders(array $params)
+    {
+        return array_merge(
+            parent::getAccessTokenRequestHeaders($params),
+            [
+              'Content-Type' => 'application/x-www-form-urlencoded',
+            ]
+        );
+    }
+}

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -563,9 +563,14 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     public function testDefaultAuthorizationHeaders()
     {
         $provider = $this->getAbstractProviderMock();
-
         $headers = $provider->getAuthorizationHeaders();
-
         $this->assertEquals([], $headers);
+    }
+
+    public function testAccessTokenRequestHeaders()
+    {
+      $method = $this->getMethod(AbstractProvider::class, 'getAccessTokenRequest');
+      $request = $method->invoke($this->provider, []);
+      $this->assertEquals(['application/x-www-form-urlencoded'], $request->getHeader('content-type'));
     }
 }

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -4,6 +4,7 @@ namespace League\OAuth2\Client\Test\Provider;
 
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
+use League\OAuth2\Client\Tool\UrlEncodedRequestTrait;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Psr\Http\Message\ResponseInterface;
@@ -11,6 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 class Fake extends AbstractProvider
 {
     use BearerAuthorizationTrait;
+    use UrlEncodedRequestTrait;
 
     private $accessTokenMethod = 'POST';
 


### PR DESCRIPTION
This PR is an alternative to #381, aiming to solve #340 and #348.

Makes use of a new method called `getAccessTokenRequestHeaders` and a trait called `UrlEncodedRequestTrait`.

The only thing I'm thinking here is why not use `getDefaultHeaders` instead? See #383