### PR TITLE
Second alternative solution to set access token request headers

### DIFF
--- a/src/Tool/UrlEncodedRequestTrait.php
+++ b/src/Tool/UrlEncodedRequestTrait.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of the league/oauth2-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Alex Bilbie <hello@alexbilbie.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth2-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth2-client Packagist
+ * @link https://github.com/thephpleague/oauth2-client GitHub
+ */
+
+namespace League\OAuth2\Client\Tool;
+
+/**
+ *
+ */
+trait UrlEncodedRequestTrait
+{
+    protected function getDefaultHeaders()
+    {
+        return array_merge(
+            parent::getDefaultHeaders(),
+            [
+                'Content-Type' => 'application/x-www-form-urlencoded',
+            ]
+        );
+    }
+}

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -563,9 +563,14 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     public function testDefaultAuthorizationHeaders()
     {
         $provider = $this->getAbstractProviderMock();
-
         $headers = $provider->getAuthorizationHeaders();
-
         $this->assertEquals([], $headers);
+    }
+
+    public function testAccessTokenRequestHeaders()
+    {
+      $method = $this->getMethod(AbstractProvider::class, 'getAccessTokenRequest');
+      $request = $method->invoke($this->provider, []);
+      $this->assertEquals(['application/x-www-form-urlencoded'], $request->getHeader('content-type'));
     }
 }

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -4,6 +4,7 @@ namespace League\OAuth2\Client\Test\Provider;
 
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
+use League\OAuth2\Client\Tool\UrlEncodedRequestTrait;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use Psr\Http\Message\ResponseInterface;
@@ -11,6 +12,7 @@ use Psr\Http\Message\ResponseInterface;
 class Fake extends AbstractProvider
 {
     use BearerAuthorizationTrait;
+    use UrlEncodedRequestTrait;
 
     private $accessTokenMethod = 'POST';
 


### PR DESCRIPTION
This PR is an alternative to #382 , aiming to solve #340 and #348.

Uses `getDefaultHeaders` rather than creating a new `getAccessTokenRequestHeaders` method.