### PR TITLE
Add support for nested index within Access Token Resource Owner ID

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -657,7 +657,10 @@ abstract class AbstractProvider
     protected function prepareAccessTokenResponse(array $result)
     {
         if ($this->getAccessTokenResourceOwnerId()) {
-            $result['resource_owner_id'] = $result[$this->getAccessTokenResourceOwnerId()];
+            $result['resource_owner_id'] = $this->getValueByKey(
+                $this->getAccessTokenResourceOwnerId(),
+                $result
+            );
         }
         return $result;
     }
@@ -748,5 +751,37 @@ abstract class AbstractProvider
         }
 
         return $this->getDefaultHeaders();
+    }
+
+    /**
+     * Get value by key with dot notation.
+     *
+     * @param  string  $key
+     * @param  array   $data
+     * @param  mixed   $default Optional
+     *
+     * @return mixed
+     */
+    protected function getValueByKey($key, array $data, $default = null)
+    {
+        if (!is_string($key) || empty($key) || !count($data)) {
+            return $default;
+        }
+
+        if (strpos($key, '.') !== false) {
+            $keys = explode('.', $key);
+
+            foreach ($keys as $innerKey) {
+                if (!array_key_exists($innerKey, $data)) {
+                    return $default;
+                }
+
+                $data = $data[$innerKey];
+            }
+
+            return $data;
+        }
+
+        return array_key_exists($key, $data) ? $data[$key] : $default;
     }
 }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -560,6 +560,48 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result['user_id'], $newResult['resource_owner_id']);
     }
 
+    public function testPrepareAccessTokenResponseWithDotNotation()
+    {
+        $provider = m::mock(Fake\ProviderWithAccessTokenResourceOwnerId::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $result = ['user' => ['id' => uniqid()]];
+        $provider->shouldReceive('getAccessTokenResourceOwnerId')->andReturn('user.id');
+
+        $newResult = $provider->prepareAccessTokenResponse($result);
+
+        $this->assertTrue(isset($newResult['resource_owner_id']));
+        $this->assertEquals($result['user']['id'], $newResult['resource_owner_id']);
+    }
+
+    public function testPrepareAccessTokenResponseWithInvalidKeyType()
+    {
+        $provider = m::mock(Fake\ProviderWithAccessTokenResourceOwnerId::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $result = ['user_id' => uniqid()];
+
+        $provider->shouldReceive('getAccessTokenResourceOwnerId')->andReturn(new \stdClass);
+
+        $newResult = $provider->prepareAccessTokenResponse($result);
+
+        $this->assertFalse(isset($newResult['resource_owner_id']));
+    }
+
+    public function testPrepareAccessTokenResponseWithInvalidKeyPath()
+    {
+        $provider = m::mock(Fake\ProviderWithAccessTokenResourceOwnerId::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $result = ['user' => ['id' => uniqid()]];
+
+        $provider->shouldReceive('getAccessTokenResourceOwnerId')->andReturn('user.name');
+
+        $newResult = $provider->prepareAccessTokenResponse($result);
+
+        $this->assertFalse(isset($newResult['resource_owner_id']));
+    }
+
     public function testDefaultAuthorizationHeaders()
     {
         $provider = $this->getAbstractProviderMock();


### PR DESCRIPTION
The Instagram API returns a payload with a nested `User` object that contains the `uid` of  the resource owner.

```json
{
    "access_token": "fb2e77d.47a0479900504cb3ab4a1f626d174d2d",
    "user": {
        "id": "1574083",
        "username": "snoopdogg",
        "full_name": "Snoop Dogg",
        "profile_picture": "..."
    }
}
```

Currently, the providers only support "root" indexes. This solution provides support to access nested indexes using dot notation.

This solution would allow provider implementations to indicate nested resource owner id's in access token responses.

```php
    /**
     * @var string Key used in the access token response to identify the resource owner.
     */
    const ACCESS_TOKEN_RESOURCE_OWNER_ID = 'user.id';
```