### PR TITLE
Always attempt to parse as JSON and fallback on failure

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -641,7 +641,13 @@ abstract class AbstractProvider
             return $parsed;
         }
 
-        return $content;
+        // Attempt to parse the string as JSON anyway,
+        // since some providers use non-standard content types.
+        try {
+            return $this->parseJson($content);
+        } catch (UnexpectedValueException $e) {
+            return $content;
+        }
     }
 
     /**


### PR DESCRIPTION
I've run into a few cases where the content-type returned is `text/html` while the body is JSON. In this way, we attempt to parse it as JSON, and if it fails, we fall back to just returning the content as is.