### PR TITLE
Use the Bearer authorization header for the generic provider

### DIFF
--- a/src/Provider/GenericProvider.php
+++ b/src/Provider/GenericProvider.php
@@ -17,10 +17,13 @@ namespace League\OAuth2\Client\Provider;
 use InvalidArgumentException;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use Psr\Http\Message\ResponseInterface;
 
 class GenericProvider extends AbstractProvider
 {
+    use BearerAuthorizationTrait;
+
     /**
      * @var string
      */


### PR DESCRIPTION
The `GenericProvider` was failing to send authenticated requests to anything, since it didn't specify any authorization headers (or provide a means to set them). I have opted to default to the Bearer token authorization header for the generic provider.