### PR TITLE
Skip JSON content type check

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -661,10 +661,15 @@ abstract class AbstractProvider
         }
 
         // Attempt to parse the string as JSON regardless of content type,
-        // since some providers use non-standard content types.
+        // since some providers use non-standard content types. Only throw an
+        // exception if the JSON could not be parsed when it was expected to.
         try {
             return $this->parseJson($content);
         } catch (UnexpectedValueException $e) {
+            if (strpos($type, 'json') !== false) {
+                throw $e;
+            }
+
             return $content;
         }
     }

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -655,16 +655,12 @@ abstract class AbstractProvider
         $content = (string) $response->getBody();
         $type = $this->getContentType($response);
 
-        if (strpos($type, 'json') !== false) {
-            return $this->parseJson($content);
-        }
-
         if (strpos($type, 'urlencoded') !== false) {
             parse_str($content, $parsed);
             return $parsed;
         }
 
-        // Attempt to parse the string as JSON anyway,
+        // Attempt to parse the string as JSON regardless of content type,
         // since some providers use non-standard content types.
         try {
             return $this->parseJson($content);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -480,7 +480,31 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         return $method;
     }
 
-    private function _testParse($body, $type, $expected = null)
+    public function parseResponseProvider()
+    {
+        return [
+            [
+                'body'    => '{"a": 1}',
+                'type'    => 'application/json',
+                'parsed'  => ['a' => 1]
+            ],
+            [
+                'body'    => 'string',
+                'type'    => 'unknown',
+                'parsed'  => 'string'
+            ],
+            [
+                'body'    => 'a=1&b=2',
+                'type'    => 'application/x-www-form-urlencoded',
+                'parsed'  => ['a' => 1, 'b' => 2]
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parseResponseProvider
+     */
+    public function testParseResponse($body, $type, $parsed)
     {
         $method = $this->getMethod(AbstractProvider::class, 'parseResponse');
 
@@ -491,22 +515,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $response->shouldReceive('getBody')->andReturn($stream);
         $response->shouldReceive('getHeader')->with('content-type')->andReturn($type);
 
-        $this->assertEquals($expected, $method->invoke($this->provider, $response));
-    }
-
-    public function testParseJson()
-    {
-        $this->_testParse('{"a": 1}', 'application/json', ['a' => 1]);
-    }
-
-    public function testParseUnknownType()
-    {
-        $this->_testParse('success', 'unknown/mime', 'success');
-    }
-
-    public function testParseUrlParams()
-    {
-        $this->_testParse('a=1&b=2', 'application/x-www-form-urlencoded', ['a' => 1, 'b' => 2]);
+        $this->assertEquals($parsed, $method->invoke($this->provider, $response));
     }
 
     /**
@@ -514,7 +523,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseResponseJsonFailure()
     {
-        $this->_testParse('{a: 1}', 'application/json');
+        $this->testParseResponse('{a: 1}', 'application/json', null);
     }
 
     public function getAppendQueryProvider()


### PR DESCRIPTION
Seeing as we're attempting to parse JSON anyway, I don't see the point of checking the JSON content type. I don't really like how we're using the exception here but it makes sense from a practical point of view.