### PR TITLE
Add toArray to ResourceOwnerInterface

### DIFF
--- a/src/Provider/ResourceOwnerInterface.php
+++ b/src/Provider/ResourceOwnerInterface.php
@@ -25,4 +25,11 @@ interface ResourceOwnerInterface
      * @return mixed
      */
     public function getId();
+    
+    /**
+     * Return all of the owner details available as an array.
+     *
+     * @return array
+     */
+    public function toArray();
 }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -183,6 +183,9 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($id, $user->getId());
         $this->assertEquals($name, $user->getUserScreenName());
         $this->assertEquals($email, $user->getUserEmail());
+
+        $this->assertArrayHasKey('name', $user->toArray());
+        $this->assertArrayHasKey('email', $user->toArray());
     }
 
     public function userPropertyProvider()

--- a/test/src/Provider/Fake/User.php
+++ b/test/src/Provider/Fake/User.php
@@ -30,4 +30,9 @@ class User implements ResourceOwnerInterface
     {
         return $this->response['name'];
     }
+
+    public function toArray()
+    {
+        return $this->response;
+    }
 }


### PR DESCRIPTION
Provides a more consistent way to fetch whatever information is available about the resource owner, without assuming any particular structure.