### PR TITLE
Pass ResponseInterface to IdentityProviderException

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -679,7 +679,7 @@ abstract class AbstractProvider
      *
      * @throws IdentityProviderException
      * @param  ResponseInterface $response
-     * @param  string $data Parsed response data
+     * @param  array|string $data Parsed response data
      * @return void
      */
     abstract protected function checkResponse(ResponseInterface $response, $data);

--- a/src/Provider/Exception/IdentityProviderException.php
+++ b/src/Provider/Exception/IdentityProviderException.php
@@ -14,6 +14,8 @@
 
 namespace League\OAuth2\Client\Provider\Exception;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  *
  */
@@ -24,7 +26,12 @@ class IdentityProviderException extends \Exception
      */
     protected $response;
 
-    public function __construct($message, $code, $response)
+    /**
+     * @param string $message
+     * @param int $code
+     * @param ResponseInterface $response
+     */
+    public function __construct($message, $code, ResponseInterface $response)
     {
         $this->response = $response;
 

--- a/src/Provider/Exception/IdentityProviderException.php
+++ b/src/Provider/Exception/IdentityProviderException.php
@@ -14,8 +14,6 @@
 
 namespace League\OAuth2\Client\Provider\Exception;
 
-use Psr\Http\Message\ResponseInterface;
-
 /**
  *
  */

--- a/src/Provider/Exception/IdentityProviderException.php
+++ b/src/Provider/Exception/IdentityProviderException.php
@@ -29,9 +29,9 @@ class IdentityProviderException extends \Exception
     /**
      * @param string $message
      * @param int $code
-     * @param ResponseInterface $response
+     * @param array|string $response The response body
      */
-    public function __construct($message, $code, ResponseInterface $response)
+    public function __construct($message, $code, $response)
     {
         $this->response = $response;
 
@@ -41,7 +41,7 @@ class IdentityProviderException extends \Exception
     /**
      * Returns the exception's response body.
      *
-     * @return ResponseInterface
+     * @return array|string
      */
     public function getResponseBody()
     {

--- a/src/Provider/GenericProvider.php
+++ b/src/Provider/GenericProvider.php
@@ -208,7 +208,7 @@ class GenericProvider extends AbstractProvider
         if (!empty($data[$this->responseError])) {
             $error = $data[$this->responseError];
             $code  = $this->responseCode ? $data[$this->responseCode] : 0;
-            throw new IdentityProviderException($error, $code, $response);
+            throw new IdentityProviderException($error, $code, $data);
         }
     }
 

--- a/src/Provider/GenericProvider.php
+++ b/src/Provider/GenericProvider.php
@@ -208,7 +208,7 @@ class GenericProvider extends AbstractProvider
         if (!empty($data[$this->responseError])) {
             $error = $data[$this->responseError];
             $code  = $this->responseCode ? $data[$this->responseCode] : 0;
-            throw new IdentityProviderException($error, $code, $data);
+            throw new IdentityProviderException($error, $code, $response);
         }
     }
 


### PR DESCRIPTION
I came across this while updating class docblock information.

Previously, `checkResponse()` passed `$data` to `IdentityProviderException`. However, this looks incorrect, since the third parameter for `IdentityProviderException` is labeled as `$response` and its `getResponseBody()` method says it returns a `ResponseInterface`. So, it seemed to me that passing in `$data` was incorrect, but I'm not sure, so I'll need some eyes on this to tell me if this is the intended behavior.

If accepted, this will also type-hint the `$response` parameter on `IdentityProviderException` as a `ResponseInterface` to make it clearer what it expects.

Should the `getResponseBody()` method name be changed to `getResponse()`, since it's not returning a body but a full response?