### PR TITLE
[WIP] Main site initial implementation

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -1,2 +1,8 @@
 Getting Started:
     Introduction: '/'
+    "Basic Usage": '/usage/'
+
+Providers:
+    "Official Providers": '/providers/league/'
+    "Third-Party Providers": '/providers/thirdparty/'
+    "Implementing Your Own": '/providers/implementing/'

--- a/_data/project.yml
+++ b/_data/project.yml
@@ -1,5 +1,5 @@
-title:
-tagline:
+title: OAuth 2 Client
+tagline: Easy integration with OAuth2 service providers
 description:
 google_analytics_tracking_id:
 base_href:

--- a/index.md
+++ b/index.md
@@ -1,8 +1,40 @@
 ---
 layout: default
 permalink: /
-title: Introduction
+title: oauth2-client
 ---
 
-Introduction
-============
+League/oauth2-client
+======================
+
+[![Gitter Chat](https://img.shields.io/badge/gitter-join_chat-brightgreen.svg?style=flat-square)](https://gitter.im/thephpleague/oauth2-client)
+[![Source Code](http://img.shields.io/badge/source-thephpleague/oauth2--client-blue.svg?style=flat-square)](https://github.com/thephpleague/oauth2-client)
+[![Latest Version](https://img.shields.io/github/release/thephpleague/oauth2-client.svg?style=flat-square)](https://github.com/thephpleague/oauth2-client/releases)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/thephpleague/oauth2-client/blob/master/LICENSE)
+[![Build Status](https://img.shields.io/travis/thephpleague/oauth2-client/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/oauth2-client)
+[![HHVM Status](https://img.shields.io/hhvm/league/oauth2-client.svg?style=flat-square)](http://hhvm.h4cc.de/package/league/oauth2-client)
+[![Coverage Status](https://img.shields.io/coveralls/thephpleague/oauth2-client/master.svg?style=flat-square)](https://coveralls.io/r/thephpleague/oauth2-client?branch=master)
+[![Total Downloads](https://img.shields.io/packagist/dt/league/oauth2-client.svg?style=flat-square)](https://packagist.org/packages/league/oauth2-client)
+
+The OAuth2 login flow, seen commonly around the web in the form of "Connect with Facebook/Google/etc." buttons, is a very
+common integration added to web applications, that can be a bit tricky and tedious to do right.
+
+The `league/oauth2-client` package provides an easy base for integration with various OAuth 2.0 Providers around the web,
+without overburdening your application with the concerns of [RFC 6749](http://tools.ietf.org/html/rfc6749).
+
+Installation
+-------------
+
+This package establishes a convenient base of interfaces and abstract classes that allow developers to easily create
+OAuth2 Clients to interface with a wide-variety of providers on the web. There are many clients that exist that you may
+use on the [Third-Party Providers]('/providers/thirdparty') page.
+
+This base package also includes a `GenericProvider` that can be used with any OAuth 2.0 Server that uses [Bearer tokens](http://tools.ietf.org/html/rfc6750).
+
+If you would like to simply use that, you can install this package via composer.
+
+~~~ bash
+$ composer require league/oauth2-client
+~~~
+
+

--- a/providers/implementing.md
+++ b/providers/implementing.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: Implementing Your Own Provider
+permalink: /providers/implementing/
+---
+
+Implementing a Provider
+========================
+
+> Hint: New providers may be created by copying the layout of an existing package. See
+the [first party](/providers/league) and [third party](/providers/thirdparty) providers for good examples.
+
+When choosing a name for your package, please don’t use the `league` vendor
+prefix, as this implies that it is officially supported. You should use your own
+username as the vendor prefix, and prepend `oauth2-` to the package name to make
+it clear that your package works with OAuth2 Client. For example, if your GitHub
+username was "santa," and you were implementing the "giftpay" OAuth2 library, a
+good name for your composer package would be `santa/oauth2-giftpay`.
+
+If you are working with an oauth2 service not supported out-of-the-box or by an
+existing package, it is quite simple to implement your own. Simply extend
+[`League\OAuth2\Client\Provider\AbstractProvider`](https://github.com/thephpleague/oauth2-client/blob/master/src/Provider/AbstractProvider.php)
+and implement the required abstract methods:
+
+~~~ php
+abstract public function getBaseAuthorizationUrl();
+abstract public function getBaseAccessTokenUrl(array $params);
+abstract public function getResourceOwnerDetailsUrl(AccessToken $token);
+abstract protected function getDefaultScopes();
+abstract protected function checkResponse(ResponseInterface $response, $data);
+abstract protected function createResourceOwner(array $response, AccessToken $token);
+~~~
+
+Each of these abstract methods contain a docblock defining their expectations
+and typical behavior. Once you have extended this class, you can simply follow
+the [basic usage example](/usage) using your new `Provider`.
+
+Resource owner identifiers in access token responses
+-----------------------------------------------------
+
+In services where the resource owner is a person, the resource owner is sometimes
+referred to as an end-user.
+
+We have decided to abstract away as much of the resource owner details as possible,
+since these are not part of the OAuth 2.0 specification and are very specific to each
+service provider. This provides greater flexibility to each provider, allowing
+them to handle the implementation details for resource owners.
+
+The `AbstractProvider` does not specify an access token resource owner identifier. It is
+the responsibility of the provider class to set the `ACCESS_TOKEN_RESOURCE_OWNER_ID` constant
+to the string value of the key used in the access token response to identify the
+resource owner.
+
+~~~ php
+/**
+ * @var string Key used in the access token response to identify the resource owner.
+ */
+const ACCESS_TOKEN_RESOURCE_OWNER_ID = null;
+~~~
+
+Once this is set on your provider, when calling `AbstractProvider::getAccessToken()`,
+the `AccessToken` returned will have its `$resourceOwnerId` property set, which you may
+retrieve by calling `AccessToken::getResourceOwnerId()`.
+
+The next step is to implement the `AbstractProvider::createResourceOwner()` method. This
+method accepts as parameters a response array and an `AccessToken`. You may use
+this information in order to request resource owner details from your service and
+construct and return an object that implements
+[`League\OAuth2\Client\Provider\ResourceOwnerInterface`](https://github.com/thephpleague/oauth2-client/blob/master/src/Provider/ResourceOwnerInterface.php).
+This object is returned when calling `AbstractProvider::getResourceOwner()`.
+
+Make it available
+------------------
+
+If you find a package for a certain provider useful, chances are someone else will too! Make your package available by
+putting it on [packagist](http://packagist.org) and [GitHub](https://github.com)! After it's available, submit a pull request
+to the [oauth2-client](https://github.com/thephpleague/oauth2-client) repository adding your provider to the provider list.
+
+Make your gateway official
+---------------------------
+
+If you want to transfer your provider to the `thephpleague` GitHub organization
+and add it to the list of officially supported providers, please open a pull
+request on the thephpleague/oauth2-client package. Before new providers will be
+accepted, they must have 100% unit test code coverage, and follow the
+conventions and code style used in other OAuth2 Client providers.

--- a/providers/league.md
+++ b/providers/league.md
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Official Providers
+permalink: /providers/league/
+---
+
+Official Providers
+===============================
+
+Due to the vast (and ever-growing) number of OAuth 2.0 services that exist, it would be impossible to maintain first-party
+support for every OAuth 2 provider without damaging our ability to make this package the best it can be. Therefore we will only accept
+very high-quality providers into the `league` namespace on a case-by-case basis. You can find some of the criteria on the 
+[third-party providers page](/providers/thirdparty)
+
+There are a [large number of community packages](/providers/thirdparty) that interface with other systems.
+
+Installation of any of these packages can be done with composer:
+
+~~~ bash
+$ composer require league/<package-name>
+~~~
+
+Gateway | Composer Package | Maintainer
+--- | --- | ---
+[Facebook](https://github.com/thephpleague/oauth2-facebook) | league/oauth2-facebook | [Sammy Kaye Powers](https://github.com/sammyk)
+[Github](https://github.com/thephpleague/oauth2-github) | league/oauth2-github | [Steven Maguire](https://github.com/stevenmaguire)
+[Google](https://github.com/thephpleague/oauth2-google) | league/oauth2-google | [Woody Gilk](https://github.com/shadowhand)
+[Instagram](https://github.com/thephpleague/oauth2-instagram) | league/oauth2-instagram | [Steven Maguire](https://github.com/stevenmaguire)
+[LinkedIn](https://github.com/thephpleague/oauth2-linkedin) | league/oauth2-linkedin | [Steven Maguire](https://github.com/stevenmaguire)

--- a/providers/thirdparty.md
+++ b/providers/thirdparty.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: "Third-Party Providers"
+permalink: /providers/thirdparty/
+---
+
+Third-Party Providers
+======================
+
+These providers allow integration with other providers not supported by `oauth2-client`. They may require an older 
+version so please help them out with a pull request if you notice this. If you're looking for an official `league` provider,
+you can check out the [first party providers](/providers/league) page.
+
+Since all of these packages depend on `league/oauth2-client` as their base, installation is as simple as requiring the
+package you wish to use via composer:
+
+~~~ bash
+$ composer require [vendor/package-name]
+~~~
+
+Gateway | Composer Package | Maintainer
+--- | --- | ---
+[Amazon](https://github.com/lemonstand/oauth2-amazon/) | lemonstand/oauth2-amazon | [LemonStand](https://github.com/lemonstand)
+[Auth0](https://github.com/RiskioFr/oauth2-auth0) | riskio/oauth2-auth0 | [Riskio](https://github.com/RiskioFr)
+[Battle.net](https://github.com/tpavlek/oauth2-bnet) | depotwarehouse/oauth2-bnet | [Troy Pavlek](https://github.com/tpavlek)
+[Bitbucket](https://github.com/stevenmaguire/oauth2-bitbucket) | stevenmaguire/oauth2-bitbucket | [Steven Maguire](https://github.com/stevenmaguire)
+[BookingSync](https://github.com/BookingSync/oauth2-bookingsync-php) | bookingsync/oauth2-bookingsync-php | [BookingSync](https://github.com/BookingSync)
+[Box](https://github.com/stevenmaguire/oauth2-box) | stevenmaguire/oauth2-box | [Steven Maguire](https://github.com/stevenmaguire)
+[Clover](https://github.com/wheniwork/oauth2-clover) | wheniwork/oauth2-clover | [When I Work](https://github.com/wheniwork)
+[Coinbase](https://github.com/openclerk/coinbase-oauth2) | openclerk/coinbase-oauth2 | [Openclerk](https://github.com/openclerk)
+[Dropbox](https://github.com/pixelfear/oauth2-dropbox) | pixelfear/oauth2-dropbox | [Jason Varga](https://github.com/jasonvarga)
+[Envato](https://github.com/dilab/envato-oauth2-provider) | dilab/envato-oauth2-provider | [Xu Ding](https://github.com/dilab)
+[Eventbrite](https://github.com/stevenmaguire/oauth2-eventbrite) | stevenmaguire/oauth2-eventbrite | [Steven Maguire](https://github.com/stevenmaguire)
+[FreeAgent](https://github.com/CloudManaged/oauth2-freeagent) | cloudmanaged/oauth2-freeagent | [Israel Sotomayor](https://github.com/zot24)
+[Google Nest](https://github.com/JC5/nest-oauth2-provider) | grumpydictator/nest-oauth2-provider | [James Cole](https://github.com/JC5)
+[Mail.ru](https://packagist.org/packages/aego/oauth2-mailru) | aego/oauth2-mailru | [Alexey](https://github.com/rakeev)
+[Meetup](https://github.com/howlowck/meetup-oauth2-provider) | howlowck/meetup-oauth2-provider | [Hao Luo](https://github.com/howlowck)
+[Microsoft](https://github.com/stevenmaguire/oauth2-microsoft) | stevenmaguire/oauth2-microsoft | [Steven Maguire](https://github.com/stevenmaguire)
+[Naver](https://packagist.org/packages/deminoth/oauth2-naver) | deminoth/oauth2-naver | [SangYeob Bono Yu](https://github.com/deminoth)
+[Odnoklassniki](https://packagist.org/packages/aego/oauth2-odnoklassniki) | aego/oauth2-odnoklassniki | [Alexey](https://github.com/rakeev)
+[Reddit](https://github.com/rtheunissen/oauth2-reddit) | rtheunissen/oauth2-reddit | [Rudi Theunissen](https://github.com/rtheunissen)
+[Spotify](https://packagist.org/packages/audeio/spotify-web-api) | audeio/spotify-web-api | [Jonjo McKay](https://github.com/jonjomckay)
+[Square](https://packagist.org/packages/wheniwork/oauth2-square) | wheniwork/oauth2-square | [Woody Gilk](https://github.com/shadowhand)
+[Twitch.tv](https://github.com/tpavlek/oauth2-twitch) | depotwarehouse/oauth2-twitch | [Troy Pavlek](https://github.com/tpavlek)
+[Uber](https://github.com/stevenmaguire/oauth2-uber) | stevenmaguire/oauth2-uber | [Steven Maguire](https://github.com/stevenmaguire)
+[Vend](https://github.com/wheniwork/oauth2-vend) | wheniwork/oauth2-vend | [When I Work](https://github.com/wheniwork)
+[Vkontakte](https://github.com/j4k/oauth2-vkontakte) | j4k/oauth2-vkontakte | [Jack W](https://github.com/j4k)
+[Yandex](https://packagist.org/packages/aego/oauth2-yandex) | aego/oauth2-yandex | [Alexey](https://github.com/rakeev)
+[ZenPayroll](https://packagist.org/packages/wheniwork/oauth2-zenpayroll) | wheniwork/oauth2-zenpayroll | [Woody Gilk](https://github.com/shadowhand)

--- a/usage.md
+++ b/usage.md
@@ -1,0 +1,122 @@
+---
+layout: default
+permalink: /usage/
+title: "Basic Usage"
+---
+
+Basic Usage
+=============
+
+> Note: In most cases, you'll be much better served by using a specific [official](/providers/league) or [third-party](/providers/thirdparty)
+provider client library rather than this base library alone.
+
+Authorization Code Flow
+-------------------------
+
+The following example uses the out-of-the-box `GenericProvider` provided by this library. 
+
+The authorization code grant type is the most common grant type used when authenticating users with a third-party service. This grant type utilizes a client (this library), a server (the service provider), and a resource owner (the user with credentials to a protected—or owned—resource) to request access to resources owned by the user. This is often referred to as _3-legged OAuth_, since there are three parties involved.
+
+The following example illustrates this using [Brent Shaffer's](https://github.com/bshaffer) demo OAuth 2.0 application named **Lock'd In**. When running this code, you will be redirected to Lock'd In, where you'll be prompted to authorize the client to make requests to a resource on your behalf.
+
+Now, you don't really have an account on Lock'd In, but for the sake of this example, imagine that you are already logged in on Lock'd In when you are redirected there.
+
+~~~ php
+$provider = new \League\OAuth2\Client\Provider\GenericProvider([
+    'clientId'                => 'demoapp',    // The client ID assigned to you by the provider
+    'clientSecret'            => 'demopass',   // The client password assigned to you by the provider
+    'redirectUri'             => 'http://example.com/your-redirect-url/',
+    'urlAuthorize'            => 'http://brentertainment.com/oauth2/lockdin/authorize',
+    'urlAccessToken'          => 'http://brentertainment.com/oauth2/lockdin/token',
+    'urlResourceOwnerDetails' => 'http://brentertainment.com/oauth2/lockdin/resource'
+]);
+
+// If we don't have an authorization code then get one
+if (!isset($_GET['code'])) {
+
+    // Fetch the authorization URL from the provider; this returns the
+    // urlAuthorize option and generates and applies any necessary parameters
+    // (e.g. state).
+    $authorizationUrl = $provider->getAuthorizationUrl();
+
+    // Get the state generated for you and store it to the session.
+    $_SESSION['oauth2state'] = $provider->getState();
+
+    // Redirect the user to the authorization URL.
+    header('Location: ' . $authorizationUrl);
+    exit;
+
+// Check given state against previously stored one to mitigate CSRF attack
+} elseif (empty($_GET['state']) || ($_GET['state'] !== $_SESSION['oauth2state'])) {
+
+    unset($_SESSION['oauth2state']);
+    exit('Invalid state');
+
+} else {
+
+    try {
+
+        // Try to get an access token using the authorization code grant.
+        $accessToken = $provider->getAccessToken('authorization_code', [
+            'code' => $_GET['code']
+        ]);
+
+        // We have an access token, which we may use in authenticated
+        // requests against the service provider's API.
+        echo $accessToken->getToken() . "\n";
+        echo $accessToken->getRefreshToken() . "\n";
+        echo $accessToken->getExpires() . "\n";
+        echo ($accessToken->hasExpired() ? 'expired' : 'not expired') . "\n";
+
+        // Using the access token, we may look up details about the
+        // resource owner.
+        $resourceOwner = $provider->getResourceOwner($accessToken);
+
+        var_export($resourceOwner->toArray());
+
+        // The provider provides a way to get an authenticated API request for
+        // the service, using the access token; it returns an object conforming
+        // to Psr\Http\Message\RequestInterface.
+        $request = $provider->getAuthenticatedRequest(
+            'GET',
+            'http://brentertainment.com/oauth2/lockdin/resource',
+            $accessToken
+        );
+
+    } catch (\League\OAuth2\Client\Provider\Exception\IdentityProviderException $e) {
+
+        // Failed to get the access token or user details.
+        exit($e->getMessage());
+
+    }
+
+}
+~~~
+
+Refreshing a Token
+-------------------
+
+Once your application is authorized, you can refresh an expired token using a refresh token rather than going through the entire process of obtaining a brand new token. To do so, simply reuse this refresh token from your data store to request a refresh.
+
+_This example uses [Brent Shaffer's](https://github.com/bshaffer) demo OAuth 2.0 application named **Lock'd In**. See authorization code example above, for more details._
+
+~~~ php
+$provider = new \League\OAuth2\Client\Provider\GenericProvider([
+    'clientId'                => 'demoapp',    // The client ID assigned to you by the provider
+    'clientSecret'            => 'demopass',   // The client password assigned to you by the provider
+    'redirectUri'             => 'http://example.com/your-redirect-url/',
+    'urlAuthorize'            => 'http://brentertainment.com/oauth2/lockdin/authorize',
+    'urlAccessToken'          => 'http://brentertainment.com/oauth2/lockdin/token',
+    'urlResourceOwnerDetails' => 'http://brentertainment.com/oauth2/lockdin/resource'
+]);
+
+$existingAccessToken = getAccessTokenFromYourDataStore();
+
+if ($existingAccessToken->hasExpired()) {
+    $newAccessToken = $provider->getAccessToken('refresh_token', [
+        'refresh_token' => $existingAccessToken->getRefreshToken()
+    ]);
+
+    // Purge old access token and store new access token to your data store.
+}
+~~~


### PR DESCRIPTION
This is an initial implementation of the gh-pages branch to better document the client. For the most part, it was taking the information that already exists in the READMEs, adjusting some of it to fit the site format, and putting it in.

I'd probably suggest once the site is completed, we decommission some of the READMEs to avoid having to maintain information in two places. The one caveat with that is it makes it more difficult for less-experienced contributors to submit a pull with their new provider implementation - maybe we'll just have to have them file an issue instead?

Another thing I'm really unhappy with with the documentation right now is the usage example. It's fine, I suppose, but I feel the general user of this package is probably using a framework, and the usage example is framed as a "single script", which can be hard to contextualize for new developers using something like Laravel, which has a very expressive and developer-friendly syntax. Are we opposed to adding a page that adds a more contextual example eg. "Create a redirect method in your controller, that returns `$provider->getAuthorizationUrl()`"? I think there's probably a lot of value to that.