### PR TITLE
[2.0] Make getResponse consistent with getRequest

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -533,7 +533,7 @@ abstract class AbstractProvider
 
         $params   = $grant->prepareRequestParameters($params, $options);
         $request  = $this->getAccessTokenRequest($params);
-        $response = $this->getResponse($request);
+        $response = $this->getParsedResponse($request);
         $prepared = $this->prepareAccessTokenResponse($response);
         $token    = $this->createAccessToken($prepared, $grant);
 
@@ -596,7 +596,7 @@ abstract class AbstractProvider
      * @param  RequestInterface $request
      * @return ResponseInterface
      */
-    protected function sendRequest(RequestInterface $request)
+    protected function getResponse(RequestInterface $request)
     {
         try {
             $response = $this->getHttpClient()->send($request);
@@ -610,11 +610,11 @@ abstract class AbstractProvider
      * Sends a request and returns the parsed response.
      *
      * @param  RequestInterface $request
-     * @return mixed
+     * @return array|string
      */
-    public function getResponse(RequestInterface $request)
+    public function getParsedResponse(RequestInterface $request)
     {
-        $response = $this->sendRequest($request);
+        $response = $this->getResponse($request);
         $parsed = $this->parseResponse($response);
 
         $this->checkResponse($response, $parsed);
@@ -660,7 +660,7 @@ abstract class AbstractProvider
      *
      * @throws UnexpectedValueException
      * @param  ResponseInterface $response
-     * @return array
+     * @return array|string
      */
     protected function parseResponse(ResponseInterface $response)
     {
@@ -702,18 +702,26 @@ abstract class AbstractProvider
      * Custom mapping of expiration, etc should be done here. Always call the
      * parent method when overloading this method.
      *
-     * @param  mixed $result
-     * @return array
+     * @param  array|string $response
+     * @return array|string
+     * @throws UnexpectedValueException
      */
-    protected function prepareAccessTokenResponse(array $result)
+    protected function prepareAccessTokenResponse($response)
     {
         if ($this->getAccessTokenResourceOwnerId() !== null) {
-            $result['resource_owner_id'] = $this->getValueByKey(
+            if (!is_array($response)) {
+                throw new UnexpectedValueException(
+                    "Array type expected for access token response"
+                );
+            }
+
+            $response['resource_owner_id'] = $this->getValueByKey(
                 $this->getAccessTokenResourceOwnerId(),
-                $result
+                $response
             );
         }
-        return $result;
+
+        return $response;
     }
 
     /**
@@ -766,7 +774,7 @@ abstract class AbstractProvider
 
         $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);
 
-        return $this->getResponse($request);
+        return $this->getParsedResponse($request);
     }
 
     /**

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -329,6 +329,16 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testNonArrayThrowsExceptionWhenPreparingAccessTokenResponse()
+    {
+        $provider = m::mock(Fake\ProviderWithAccessTokenResourceOwnerId::class);
+        $provider->prepareAccessTokenResponse('string');
+    }
+
+
+    /**
      * @expectedException \League\OAuth2\Client\Provider\Exception\IdentityProviderException
      */
     public function testClientErrorTriggersProviderException()
@@ -400,7 +410,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $provider->setHttpClient($client);
 
         // Final result should be a parsed response
-        $result = $provider->getResponse($request);
+        $result = $provider->getParsedResponse($request);
         $this->assertSame(['example' => 'response'], $result);
     }
 


### PR DESCRIPTION
I realise that this breaks BC, so it would have to be a part of the next major version.

This came up when I was looking at [an issue that Scrutinizer pointed out](https://scrutinizer-ci.com/g/thephpleague/oauth2-client/issues/master/files/src/Provider/AbstractProvider.php?orderField=path&order=asc#inspectioncomment-1186598870), where the current `getResponse` returns a _parsed_ response, which could be a string or an array (or null?). But the required type for the response parameter in `prepareAccessTokenResponse` is only `array`.

It doesn't _realistically_ make sense for an access token response to **not** be an array, but from a purely correct and well documented code point of view, this seems inconsistent. It's not clear that getResponse returns a parsed response, where getRequest returns a `RequestInterface`.

If for whatever reason the value passed to `prepareAccessTokenResponse` is not an array, I think an `UnexpectedValueException` is more meaningful than the default PHP error.

**Proposed solution**:
- Rename `getResponse` to `getParsedResponse`
- Rename `sendRequest` to `getResponse` 
