### PR TITLE
Changed RequiredParameterTrait to cover more cases

### DIFF
--- a/src/Tool/RequiredParameterTrait.php
+++ b/src/Tool/RequiredParameterTrait.php
@@ -31,7 +31,7 @@ trait RequiredParameterTrait
      */
     private function checkRequiredParameter($name, array $params)
     {
-        if (empty($params[$name])) {
+        if (!isset($params[$name])) {
             throw new BadMethodCallException(sprintf(
                 'Required parameter not passed: "%s"',
                 $name


### PR DESCRIPTION
There have been a couple of times now where this trait is throwing the exception because the array being checked contains `false` `"-1"`, etc.

Swapping this out for `!isset()` covers more cases.

|Expression | empty() | !isset() |
|-------|--------|------------------|
|$x = "";|FALSE|TRUE|
|$x = null;|TRUE|FALSE|
|var $x;|TRUE|FALSE|
|$x is undefined|TRUE|FALSE|
|$x = array();|TRUE|TRUE|
|$x = false;|TRUE|TRUE|
|$x = true;|FALSE|TRUE|
|$x = 1;|FALSE|TRUE|
|$x = 42;|FALSE|TRUE|
|$x = 0;|TRUE|TRUE|
|$x = -1;|FALSE|TRUE|
|$x = "1";|FALSE|TRUE|
|$x = "0";|TRUE|TRUE|
|$x = "-1";|FALSE|TRUE|
|$x = "php";|FALSE|TRUE|
|$x = "true";|FALSE|TRUE|
|$x = "false";|FALSE|TRUE|