### PR TITLE
Allow access tokens to be created from storage

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -77,9 +77,26 @@ class AccessToken implements JsonSerializable
             // Some providers supply the seconds until expiration rather than
             // the exact timestamp. Take a best guess at which we received.
             $expires = $options['expires'];
-            $expiresInFuture = $expires > time();
-            $this->expires = $expiresInFuture ? $expires : time() + ((int) $expires);
+
+            if (!$this->isExpirationTimestamp($expires)) {
+                $expires += time();
+            }
+
+            $this->expires = $expires;
         }
+    }
+
+    /**
+     * Check if a value is an expiration timestamp or second value.
+     *
+     * @return boolean
+     */
+    protected function isExpirationTimestamp($value)
+    {
+        // If the given value is larger than the original OAuth 2 draft date,
+        // assume that it is meant to be a (possible expired) timestamp.
+        $oauth2InceptionDate = 1349067600; // 2012-10-01
+        return ($value > $oauth2InceptionDate);
     }
 
     /**

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -32,6 +32,19 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
         $this->assertLessThan(time() + 200, $expires);
     }
 
+    public function testExpiresPastTimestamp()
+    {
+        $options = ['access_token' => 'access_token', 'expires' => strtotime('5 days ago')];
+        $token = $this->getAccessToken($options);
+
+        $this->assertTrue($token->hasExpired());
+
+        $options = ['access_token' => 'access_token', 'expires' => 3600];
+        $token = $this->getAccessToken($options);
+
+        $this->assertFalse($token->hasExpired());
+    }
+
     public function testGetRefreshToken()
     {
         $options = [


### PR DESCRIPTION
Previously if an access token expiration was in the past, it was assumed that the `expires` value was a second value and would make the token appear to not be expired.

To prevent this discrepancy, allow for any past timestamp after October 2012 to be used.

Fixes #431