### PR TITLE
Show code coverage results in CLI

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,8 +15,8 @@
 	<logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-text" target="php://stdout"/>
         <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
Having the coverage stored in a file is not very useful.