### PR TITLE
Add ArrayAccessorTrait

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -22,6 +22,7 @@ use League\OAuth2\Client\Grant\GrantFactory;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\RequestFactory;
+use League\OAuth2\Client\Tool\ArrayAccessorTrait;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RandomLib\Factory as RandomFactory;
@@ -34,6 +35,8 @@ use UnexpectedValueException;
  */
 abstract class AbstractProvider
 {
+    use ArrayAccessorTrait;
+
     /**
      * @var string Key used in a token response to identify the resource owner.
      */
@@ -707,8 +710,8 @@ abstract class AbstractProvider
     {
         if ($this->getAccessTokenResourceOwnerId() !== null) {
             $result['resource_owner_id'] = $this->getValueByKey(
-                $this->getAccessTokenResourceOwnerId(),
-                $result
+                $result,
+                $this->getAccessTokenResourceOwnerId()
             );
         }
         return $result;
@@ -814,36 +817,5 @@ abstract class AbstractProvider
         }
 
         return $this->getDefaultHeaders();
-    }
-
-    /**
-     * Returns a value by key using dot notation.
-     *
-     * @param  string $key
-     * @param  array $data
-     * @param  mixed|null $default
-     * @return mixed
-     */
-    protected function getValueByKey($key, array $data, $default = null)
-    {
-        if (!is_string($key) || empty($key) || !count($data)) {
-            return $default;
-        }
-
-        if (strpos($key, '.') !== false) {
-            $keys = explode('.', $key);
-
-            foreach ($keys as $innerKey) {
-                if (!array_key_exists($innerKey, $data)) {
-                    return $default;
-                }
-
-                $data = $data[$innerKey];
-            }
-
-            return $data;
-        }
-
-        return array_key_exists($key, $data) ? $data[$key] : $default;
     }
 }

--- a/src/Tool/ArrayAccessorTrait.php
+++ b/src/Tool/ArrayAccessorTrait.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of the league/oauth2-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Alex Bilbie <hello@alexbilbie.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth2-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth2-client Packagist
+ * @link https://github.com/thephpleague/oauth2-client GitHub
+ */
+
+namespace League\OAuth2\Client\Tool;
+
+/**
+ * Provides generic array navigation tools.
+ */
+trait ArrayAccessorTrait
+{
+    /**
+     * Returns a value by key using dot notation.
+     *
+     * @param  array      $data
+     * @param  string     $key
+     * @param  mixed|null $default
+     * @return mixed
+     */
+    private function getValueByKey(array $data, $key, $default = null)
+    {
+        if (!is_string($key) || empty($key) || !count($data)) {
+            return $default;
+        }
+
+        if (strpos($key, '.') !== false) {
+            $keys = explode('.', $key);
+
+            foreach ($keys as $innerKey) {
+                if (!array_key_exists($innerKey, $data)) {
+                    return $default;
+                }
+
+                $data = $data[$innerKey];
+            }
+
+            return $data;
+        }
+
+        return array_key_exists($key, $data) ? $data[$key] : $default;
+    }
+}


### PR DESCRIPTION
Previously the AbstractProvider included a protected method to parse a given array for values using the dot notation. This code is pretty generic and in building third party providers, I've discovered that it needs to be repeated for certain ResourceOwner classes. I am proposing to move this dot notation method to a new ArrayAccessorTrait so that it can serve the current internal purpose as well as serve third party purposes.