### PR TITLE
Use expires to serialize access tokens

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -186,7 +186,7 @@ class AccessToken implements JsonSerializable
         }
 
         if ($this->expires) {
-            $parameters['expires_in'] = $this->expires - time();
+            $parameters['expires'] = $this->expires;
         }
 
         return $parameters;

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -106,7 +106,7 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
         $options = [
             'access_token' => 'mock_access_token',
             'refresh_token' => 'mock_refresh_token',
-            'expires_in' => 100,
+            'expires' => time(),
         ];
 
         $token = $this->getAccessToken($options);


### PR DESCRIPTION
This fixes issue #458.