### PR TITLE
added checkAccessTokenResponse abstract function

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -536,7 +536,7 @@ abstract class AbstractProvider
 
         $params   = $grant->prepareRequestParameters($params, $options);
         $request  = $this->getAccessTokenRequest($params);
-        $response = $this->getResponse($request);
+        $response = $this->getAccessTokenResponse($request);
         $prepared = $this->prepareAccessTokenResponse($response);
         $token    = $this->createAccessToken($prepared, $grant);
 
@@ -625,6 +625,22 @@ abstract class AbstractProvider
         return $parsed;
     }
 
+    /**
+     * Sends a request and returns the parsed access token response.
+     *
+     * @param  RequestInterface $request
+     * @return mixed
+     */
+    public function getAccessTokenResponse(RequestInterface $request)
+    {
+        $response = $this->sendRequest($request);
+        $parsed = $this->parseResponse($response);
+
+        $this->checkAccessTokenResponse($response, $parsed);
+
+        return $parsed;
+    }
+
 
     /**
      * Attempts to parse a JSON response.
@@ -698,6 +714,16 @@ abstract class AbstractProvider
      * @return void
      */
     abstract protected function checkResponse(ResponseInterface $response, $data);
+
+    /**
+     * Checks a provider response for access token request errors.
+     *
+     * @throws IdentityProviderException
+     * @param  ResponseInterface $response
+     * @param  array|string $data Parsed response data
+     * @return void
+     */
+    abstract protected function checkAccessTokenResponse(ResponseInterface $response, $data);
 
     /**
      * Prepares an parsed access token response for a grant.

--- a/src/Provider/GenericProvider.php
+++ b/src/Provider/GenericProvider.php
@@ -220,6 +220,14 @@ class GenericProvider extends AbstractProvider
     /**
      * @inheritdoc
      */
+    protected function checkAccessTokenResponse(ResponseInterface $response, $data)
+    {
+        self::checkResponse($response, $data);
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function createResourceOwner(array $response, AccessToken $token)
     {
         return new GenericResourceOwner($response, $this->responseResourceOwnerId);

--- a/test/src/Provider/Fake.php
+++ b/test/src/Provider/Fake.php
@@ -55,4 +55,11 @@ class Fake extends AbstractProvider
             throw new IdentityProviderException($data['error'], $data['code'], $data);
         }
     }
+
+    protected function checkAccessTokenResponse(ResponseInterface $response, $data)
+    {
+        if (!empty($data['error'])) {
+            throw new IdentityProviderException($data['error'], $data['code'], $data);
+        }
+    }
 }


### PR DESCRIPTION
some services (atleast Github & Instagram as far as I noticed) have different error response format when a request is made to exchange the auth code for an access token.

this pull request adds a new abstract function named `checkAccessTokenResponse` which is responsible to handling the access token response and making sure it's a valid response.

this is a breaking change, as any provider will have to implement this abstract function.

Is there another solution for this issue? both providers I tried using (github & instagram) don't handle the case when an invalid auth code is used. the providers will just throw a `new InvalidArgumentException('Required option not passed: "access_token"')` exception, as the `checkResponse` doesn't recognize the error response

for example, see https://developer.github.com/v3/oauth/