### PR TITLE
Fix resource_owner_id being put into the wrong array

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -190,7 +190,7 @@ class AccessToken implements JsonSerializable
         }
 
         if ($this->resourceOwnerId) {
-            $params['resource_owner_id'] = $this->resourceOwnerId;
+            $parameters['resource_owner_id'] = $this->resourceOwnerId;
         }
 
         return $parameters;

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -101,12 +101,13 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
         $hasExpired = $token->hasExpired();
     }
 
-    public function testJsonSerialzable()
+    public function testJsonSerializable()
     {
         $options = [
             'access_token' => 'mock_access_token',
             'refresh_token' => 'mock_refresh_token',
             'expires' => time(),
+            'resource_owner_id' => 'mock_resource_owner_id',
         ];
 
         $token = $this->getAccessToken($options);


### PR DESCRIPTION
Ya'll should probably check scrutinzer some more. It highlighted this issue, albeit not the severity, when it came up. 

https://scrutinizer-ci.com/g/thephpleague/oauth2-client/inspections/044f7d1f-3923-4b78-8c04-313390c0594a/issues/files/src/Token/AccessToken.php?status=new&orderField=path&order=asc&honorSelectedPaths=0