### PR TITLE
Enable dynamic parameters being passed into the authorization URL

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -332,14 +332,11 @@ abstract class AbstractProvider
         // Store the state as it may need to be accessed later on.
         $this->state = $options['state'];
 
-        return [
-            'client_id'       => $this->clientId,
-            'redirect_uri'    => $this->redirectUri,
-            'state'           => $this->state,
-            'scope'           => $options['scope'],
-            'response_type'   => $options['response_type'],
-            'approval_prompt' => $options['approval_prompt'],
-        ];
+        $options['client_id'] = $this->clientId;
+        $options['redirect_uri'] = $this->redirectUri;
+        $options['state'] = $this->state;
+        
+        return $options;
     }
 
     /**

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -70,7 +70,9 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testCustomAuthorizationUrlOptions()
     {
-        $url = $this->provider->getAuthorizationUrl(...);
+        $url = $this->provider->getAuthorizationUrl([
+            'foo' => 'BAR'
+        ]);
         $query = parse_url($url, PHP_URL_QUERY);
         $this->assertNotEmpty($query);
         

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -64,6 +64,20 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'state' => 'XXX'
         ]));
     }
+    
+    /**
+     * Tests https://github.com/thephpleague/oauth2-client/pull/485
+     */
+    public function testCustomAuthorizationUrlOptions()
+    {
+        $url = $this->provider->getAuthorizationUrl(...);
+        $query = parse_url($url, PHP_URL_QUERY);
+        $this->assertNotEmpty($query);
+        
+        parse_str($query, $params);
+        $this->assertArrayHasKey('foo', $params);
+        $this->assertSame('BAR', $params['foo']);
+    }
 
     /**
      * Tests https://github.com/thephpleague/oauth2-client/issues/134


### PR DESCRIPTION
When for example using Azure AD, you may need to pass additional parameters to the authorization URL - like `prompt`. This change enables passing custom parameters to the authorization URL as per each provider's needs. More options for Azure AD can be found [here](https://msdn.microsoft.com/en-us/library/azure/dn645542.aspx)
For Google those are for example `access_type` or `login_hint` - found [here](https://developers.google.com/youtube/v3/guides/auth/server-side-web-apps)