### PR TITLE
Fix code styling in docs

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
     {% else %}
         <link rel="apple-touch-icon-precomposed" href="http://theme.thephpleague.com/img/apple-touch-icon-precomposed.png">
     {% endif %}
-    <link rel="stylesheet" href="http://theme.thephpleague.com/css/all.css">
+    <link rel="stylesheet" href="http://theme.thephpleague.com/css/all.css?2">
 </head>
 <body>
 
@@ -85,7 +85,6 @@
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="http://theme.thephpleague.com/js/scripts.js"></script>
-<script src="http://theme.thephpleague.com/js/prism.js"></script>
 
 {% if site.data.project.google_analytics_tracking_id %}
     <script>

--- a/providers/implementing.md
+++ b/providers/implementing.md
@@ -23,6 +23,8 @@ existing package, it is quite simple to implement your own. Simply extend
 and implement the required abstract methods:
 
 ~~~ php
+<?php
+
 abstract public function getBaseAuthorizationUrl();
 abstract public function getBaseAccessTokenUrl(array $params);
 abstract public function getResourceOwnerDetailsUrl(AccessToken $token);
@@ -52,6 +54,8 @@ to the string value of the key used in the access token response to identify the
 resource owner.
 
 ~~~ php
+<?php
+
 /**
  * @var string Key used in the access token response to identify the resource owner.
  */

--- a/usage.md
+++ b/usage.md
@@ -22,6 +22,8 @@ The following example illustrates this using [Brent Shaffer's](https://github.co
 Now, you don't really have an account on Lock'd In, but for the sake of this example, imagine that you are already logged in on Lock'd In when you are redirected there.
 
 ~~~ php
+<?php
+
 $provider = new \League\OAuth2\Client\Provider\GenericProvider([
     'clientId'                => 'demoapp',    // The client ID assigned to you by the provider
     'clientSecret'            => 'demopass',   // The client password assigned to you by the provider
@@ -101,6 +103,8 @@ Once your application is authorized, you can refresh an expired token using a re
 _This example uses [Brent Shaffer's](https://github.com/bshaffer) demo OAuth 2.0 application named **Lock'd In**. See authorization code example above, for more details._
 
 ~~~ php
+<?php
+
 $provider = new \League\OAuth2\Client\Provider\GenericProvider([
     'clientId'                => 'demoapp',    // The client ID assigned to you by the provider
     'clientSecret'            => 'demopass',   // The client password assigned to you by the provider


### PR DESCRIPTION
As per recent changes made to Github Pages, Prism is no longer a
supported highlighter.

https://github.com/blog/2100-github-pages-now-faster-and-simpler-with-jekyll-3-0