### PR TITLE
Allow using a proxy for debugging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,23 @@ try {
 }
 ```
 
+### Using a proxy
+
+It is possible to use a proxy to debug HTTP calls made to a provider. All you need to do is set the `proxy` and `verify` options when creating your Provider instance. Make sure you enable SSL proxying in your proxy.
+
+``` php
+$provider = new \League\OAuth2\Client\Provider\GenericProvider([
+    'clientId'                => 'XXXXXX',    // The client ID assigned to you by the provider
+    'clientSecret'            => 'XXXXXX',    // The client password assigned to you by the provider
+    'redirectUri'             => 'http://my.example.com/your-redirect-url/',
+    'urlAuthorize'            => 'http://service.example.com/authorize',
+    'urlAccessToken'          => 'http://service.example.com/token',
+    'urlResourceOwnerDetails' => 'http://service.example.com/resource',
+    'proxy'                   => '192.168.0.1:8888',
+    'verify'                  => false
+]);
+```
+
 ## Install
 
 Via Composer

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -122,7 +122,8 @@ abstract class AbstractProvider
         $this->setRequestFactory($collaborators['requestFactory']);
 
         if (empty($collaborators['httpClient'])) {
-            $client_options = ['timeout'];
+            $client_options = $this->getAllowedClientOptions($options);
+
             $collaborators['httpClient'] = new HttpClient(
                 array_intersect_key($options, array_flip($client_options))
             );
@@ -133,6 +134,26 @@ abstract class AbstractProvider
             $collaborators['randomFactory'] = new RandomFactory();
         }
         $this->setRandomFactory($collaborators['randomFactory']);
+    }
+
+    /**
+     * Return the list of options that can be passed to the HttpClient
+     *
+     * @param array $options An array of options to set on this provider.
+     *     Options include `clientId`, `clientSecret`, `redirectUri`, and `state`.
+     *     Individual providers may introduce more options, as needed.
+     * @return array The options to pass to the HttpClient constructor
+     */
+    protected function getAllowedClientOptions(array $options)
+    {
+        $client_options = ['timeout', 'proxy'];
+
+        // Only allow turning off ssl verification is it's for a proxy
+        if (!empty($options['proxy'])) {
+            $client_options[] = 'verify';
+        }
+
+        return $client_options;
     }
 
     /**

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -111,6 +111,38 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($timeout, $config['timeout']);
     }
 
+    public function testCanSetAProxy()
+    {
+        $proxy = '192.168.0.1:8888';
+
+        $mockProvider = new MockProvider(['proxy' => $proxy]);
+
+        $config = $mockProvider->getHttpClient()->getConfig();
+
+        $this->assertContains('proxy', $config);
+        $this->assertEquals($proxy, $config['proxy']);
+    }
+
+    public function testCannotDisableVerifyIfNoProxy()
+    {
+        $mockProvider = new MockProvider(['verify' => false]);
+
+        $config = $mockProvider->getHttpClient()->getConfig();
+
+        $this->assertContains('verify', $config);
+        $this->assertTrue($config['verify']);
+    }
+
+    public function testCanDisableVerificationIfThereIsAProxy()
+    {
+        $mockProvider = new MockProvider(['proxy' => '192.168.0.1:8888', 'verify' => false]);
+
+        $config = $mockProvider->getHttpClient()->getConfig();
+
+        $this->assertContains('verify', $config);
+        $this->assertFalse($config['verify']);
+    }
+
     public function testConstructorSetsGrantFactory()
     {
         $mockAdapter = m::mock(GrantFactory::class);


### PR DESCRIPTION
Expose the proxy and verify Guzzle options to make it possible to use a proxy. 

Verify is exposed only if a proxy is setup. Not sure if it make sense, but I don't like allowing to bypass ssl verification.