### PR TITLE
Add support for capturing access token values

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -46,6 +46,11 @@ class AccessToken implements JsonSerializable
     protected $resourceOwnerId;
 
     /**
+     * @var array
+     */
+    protected $values = [];
+
+    /**
      * Constructs an access token.
      *
      * @param array $options An array of options returned by the service provider
@@ -84,6 +89,17 @@ class AccessToken implements JsonSerializable
 
             $this->expires = $expires;
         }
+
+        // Capure any additional values that might exist in the token but are
+        // not part of the standard response. Vendors will sometimes pass
+        // additional user data this way.
+        $this->values = array_diff_key($options, array_flip([
+            'access_token',
+            'resource_owner_id',
+            'refresh_token',
+            'expires_in',
+            'expires',
+        ]));
     }
 
     /**
@@ -158,6 +174,16 @@ class AccessToken implements JsonSerializable
     }
 
     /**
+     * Returns additional vendor values stored in the token.
+     *
+     * @return array
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
      * Returns the token key.
      *
      * @return string
@@ -175,7 +201,7 @@ class AccessToken implements JsonSerializable
      */
     public function jsonSerialize()
     {
-        $parameters = [];
+        $parameters = $this->values;
 
         if ($this->accessToken) {
             $parameters['access_token'] = $this->accessToken;

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -115,4 +115,23 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($options, json_decode($jsonToken, true));
     }
+
+    public function testValues()
+    {
+        $options = [
+            'access_token' => 'mock_access_token',
+            'refresh_token' => 'mock_refresh_token',
+            'expires' => time(),
+            'resource_owner_id' => 'mock_resource_owner_id',
+            'custom_thing' => 'i am a test!',
+        ];
+
+        $token = $this->getAccessToken($options);
+
+        $values = $token->getValues();
+
+        $this->assertTrue(is_array($values));
+        $this->assertArrayHasKey('custom_thing', $values);
+        $this->assertSame($options['custom_thing'], $values['custom_thing']);
+    }
 }


### PR DESCRIPTION
Vendors (such as Google) sometimes pass additional information with
access token responses. Capturing these values allows package users to
make use of them when appropriate.

Refs thephpleague/oauth2-google#14