### PR TITLE
Ensure generated query strings are consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # OAuth 2.0 Client Changelog
 
+## 1.4.1
+
+_Released: 2016-04-29_
+
+* Add `QueryBuilderTrait` to standardize query string generation.
+
 ## 1.4.0
 
 _Released: 2016-04-19_

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -21,8 +21,9 @@ use League\OAuth2\Client\Grant\AbstractGrant;
 use League\OAuth2\Client\Grant\GrantFactory;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
-use League\OAuth2\Client\Tool\RequestFactory;
 use League\OAuth2\Client\Tool\ArrayAccessorTrait;
+use League\OAuth2\Client\Tool\QueryBuilderTrait;
+use League\OAuth2\Client\Tool\RequestFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RandomLib\Factory as RandomFactory;
@@ -36,6 +37,7 @@ use UnexpectedValueException;
 abstract class AbstractProvider
 {
     use ArrayAccessorTrait;
+    use QueryBuilderTrait;
 
     /**
      * @var string Key used in a token response to identify the resource owner.
@@ -368,7 +370,7 @@ abstract class AbstractProvider
      */
     protected function getAuthorizationQuery(array $params)
     {
-        return http_build_query($params);
+        return $this->buildQueryString($params);
     }
 
     /**
@@ -454,7 +456,7 @@ abstract class AbstractProvider
      */
     protected function getAccessTokenQuery(array $params)
     {
-        return http_build_query($params);
+        return $this->buildQueryString($params);
     }
 
     /**
@@ -500,7 +502,7 @@ abstract class AbstractProvider
      */
     protected function getAccessTokenBody(array $params)
     {
-        return http_build_query($params);
+        return $this->buildQueryString($params);
     }
 
     /**

--- a/src/Tool/QueryBuilderTrait.php
+++ b/src/Tool/QueryBuilderTrait.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the league/oauth2-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Alex Bilbie <hello@alexbilbie.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth2-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth2-client Packagist
+ * @link https://github.com/thephpleague/oauth2-client GitHub
+ */
+
+namespace League\OAuth2\Client\Tool;
+
+/**
+ * Provides a standard way to generate query strings.
+ */
+trait QueryBuilderTrait
+{
+    /**
+     * Build a query string from an array.
+     *
+     * @param array $params
+     *
+     * @return string
+     */
+    protected function buildQueryString(array $params)
+    {
+        return http_build_query($params, null, '&');
+    }
+}

--- a/test/src/Tool/QueryBuilderTraitTest.php
+++ b/test/src/Tool/QueryBuilderTraitTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace League\OAuth2\Client\Test\Tool;
+
+use League\OAuth2\Client\Tool\QueryBuilderTrait;
+use PHPUnit_Framework_TestCase;
+
+class QueryBuilderTraitTest extends PHPUnit_Framework_TestCase
+{
+    use QueryBuilderTrait;
+
+    public function setUp()
+    {
+        ini_set('arg_separator.output', '&amp;');
+    }
+
+    public function testBuildQueryString()
+    {
+        $params = [
+            'a' => 'foo',
+            'b' => 'bar',
+        ];
+
+        $query = $this->buildQueryString($params);
+
+        $this->assertSame('a=foo&b=bar', $query);
+    }
+}


### PR DESCRIPTION
PHP configuration can be modified to set a different argument
separator from the standard `&`. Generated query strings should always
use the standard separator.

Fixes #519