### PR TITLE
Should not throw nasty errors when expires_in is not set

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -76,6 +76,9 @@ class AccessToken implements JsonSerializable
         // We need to know when the token expires. Show preference to
         // 'expires_in' since it is defined in RFC6749 Section 5.1.
         // Defer to 'expires' if it is provided instead.
+        // Initialize 'expires' to false, meaning that it is not known
+        // or doesn't expire
+        $this->expires = false;
         if (!empty($options['expires_in'])) {
             $this->expires = time() + ((int) $options['expires_in']);
         } elseif (!empty($options['expires'])) {

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -20,6 +20,16 @@ class AccessTokenTest extends \PHPUnit_Framework_TestCase
         return new AccessToken($options);
     }
 
+    public function testExpiresWhenItIsNotInOptions()
+    {
+        $options = ['access_token' => 'access_token'];
+        $token = $this->getAccessToken($options);
+
+        $expires = $token->getExpires();
+
+        $this->assertFalse($expires);
+    }
+
     public function testExpiresInCorrection()
     {
         $options = ['access_token' => 'access_token', 'expires_in' => 100];


### PR DESCRIPTION
expires_in is "RECOMMENDED" as of RFC6749 but not required so there could be cases when neither is defined causing nasty errors on getExpires or hasExpired.