### PR TITLE
Implement HTTPlug

### DIFF
--- a/README.UPGRADING.md
+++ b/README.UPGRADING.md
@@ -2,6 +2,6 @@
 
 ## Upgrade Guide
 
-### Upgrading to Version 1.0.0
+### Upgrading to Version 1.5
 
-TBD
+You need to install `php-http/guzzle6-adapter` and ` php-http/message`, then use the libaray as normal.

--- a/README.md
+++ b/README.md
@@ -249,8 +249,16 @@ $provider = new \League\OAuth2\Client\Provider\GenericProvider([
 Via Composer
 
 ``` bash
-$ composer require league/oauth2-client
+$ composer require league/oauth2-client php-http/guzzle6-adapter php-http/message
 ```
+
+The two extra packages from `php-http` is part of the [HTTPlug](http://httplug.io/) organisation. It helps us not to 
+be coupled to Guzzle. That is why you need to install the `php-http/guzzle6-adapter` or any other library providing the virtual 
+[php-http/client-implementation](https://packagist.org/providers/php-http/client-implementation) package. The 
+`php-http/message` package contains factory classes to create Guzzle and Diactoros PSR-7 requests. 
+
+You can read more about HTTPlug and how to use it in 
+[their documentation](http://docs.php-http.org/en/latest/httplug/users.html).
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -4,16 +4,23 @@
     "license": "MIT",
     "require": {
         "php": ">=5.5.0",
+        "psr/http-message": "^1.0",
         "ext-curl": "*",
         "ircmaxell/random-lib": "~1.1",
-        "guzzlehttp/guzzle": "~6.0"
+        "php-http/httplug": "^1.0",
+        "php-http/client-implementation": "^1.0",
+        "php-http/message-factory": "^1.0.2",
+        "php-http/discovery": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
         "mockery/mockery": "~0.9",
         "squizlabs/php_codesniffer": "~2.0",
         "satooshi/php-coveralls": "0.6.*",
-        "jakub-onderka/php-parallel-lint": "0.8.*"
+        "php-http/message": "^1.0",
+        "php-http/guzzle6-adapter": "^1.0",
+        "jakub-onderka/php-parallel-lint": "0.8.*",
+        "symfony/phpunit-bridge": "^3.1"
     },
     "keywords": [
         "oauth",

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "satooshi/php-coveralls": "0.6.*",
         "php-http/message": "^1.0",
         "php-http/guzzle6-adapter": "^1.0",
-        "jakub-onderka/php-parallel-lint": "0.8.*",
-        "symfony/phpunit-bridge": "^3.1"
+        "jakub-onderka/php-parallel-lint": "0.8.*"
     },
     "keywords": [
         "oauth",

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -99,7 +99,8 @@ abstract class AbstractProvider
     /**
      * The options given to the Guzzle6 client
      * @var array
-     * @deprecated These are to be removed in the next major release. These options are only used in getHttpClient to keep BC.
+     * @deprecated These are to be removed in the next major release.
+     *      These options are only used in getHttpClient to keep BC.
      */
     private $guzzle6Options = [];
 
@@ -221,16 +222,36 @@ abstract class AbstractProvider
     public function setHttpClient($client)
     {
         if ($client instanceof GuzzleClientInterface) {
-            trigger_error(sprintf('Passing a "%s" to "%s::setHttpClient" is deprecated. Please use a "Http\Client\HttpClient" instead.', GuzzleClientInterface::class, static::class), E_USER_DEPRECATED);
+            @trigger_error(
+                sprintf(
+                    'Passing a "%s" to "%s::setHttpClient" is deprecated. Use a "Http\Client\HttpClient" instead.',
+                    GuzzleClientInterface::class,
+                    static::class
+                ),
+                E_USER_DEPRECATED
+            );
             if (!class_exists(HttplugGuzzle6::class)) {
-                throw new \RuntimeException(sprintf('You must install "php-http/guzzle6-adapter" to be able to pass a "%s" to "%s::setHttpClient".', GuzzleClientInterface::class, static::class));
+                throw new \RuntimeException(
+                    sprintf(
+                        'You must install "php-http/guzzle6-adapter" to be able to pass a "%s" to "%s::setHttpClient".',
+                        GuzzleClientInterface::class,
+                        static::class
+                    )
+                );
             }
             $client = new HttplugGuzzle6($client);
         }
 
         if (!$client instanceof HttpClient) {
             $type = is_object($client) ? get_class($client) : gettype($client);
-            throw new \RuntimeException(sprintf('First parameter to "%s::setHttpClient" was expected to be a "Http\Client\HttpClient", you provided a "%s"', static::class, $type));
+            throw new \RuntimeException(
+                sprintf(
+                    'First parameter to "%s::setHttpClient" was expected to be a "%s", you provided a "%s"',
+                    static::class,
+                    HttpClient::class,
+                    $type
+                )
+            );
         }
 
         $this->httpClient = $client;
@@ -255,14 +276,24 @@ abstract class AbstractProvider
      */
     public function getHttpClient()
     {
-        trigger_error(sprintf('Using "%s::getHttpClient" is deprecated in favor for "%s::getHttplugClient".', static::class, static::class), E_USER_DEPRECATED);
+        @trigger_error(
+            sprintf(
+                'Using "%s::getHttpClient" is deprecated in favor for "%s::getHttplugClient".',
+                static::class,
+                static::class
+            ),
+            E_USER_DEPRECATED
+        );
 
         if ($this->guzzleClient !== null) {
             return $this->guzzleClient;
         }
 
         if (!class_exists(GuzzleClient::class)) {
-            throw new \RuntimeException('You must install "php-http/guzzle6-adapter" to be able to use "%s::getHttplugClient".', static::class);
+            throw new \RuntimeException(
+                'You must install "php-http/guzzle6-adapter" to be able to use "%s::getHttplugClient".',
+                static::class
+            );
         }
 
         return new GuzzleClient($this->guzzle6Options);
@@ -899,23 +930,36 @@ abstract class AbstractProvider
             if (empty($guzzle6Options)) {
                 return HttpClientDiscovery::find();
             } else {
-                trigger_error('Passing options to Guzzle6 client is deprecated. Use "httplugClient" instead', E_USER_DEPRECATED);
+                @trigger_error(
+                    'Passing options to Guzzle6 client is deprecated. Use "httplugClient" instead',
+                    E_USER_DEPRECATED
+                );
                 if (!class_exists(HttplugGuzzle6::class)) {
-                    throw new \RuntimeException('You must install "php-http/guzzle6-adapter" to be able to pass options to the Guzzle6 client.');
+                    throw new \RuntimeException(
+                        'You must install "php-http/guzzle6-adapter" to be able to pass options to the Guzzle6 client.'
+                    );
                 }
                 $this->guzzle6Options = $guzzle6Options;
+
                 return HttplugGuzzle6::createWithConfig($guzzle6Options);
             }
         }
 
-        trigger_error('The "httpClient" option is deprecated. Use "httplugClient" instead', E_USER_DEPRECATED);
+        @trigger_error('The "httpClient" option is deprecated. Use "httplugClient" instead', E_USER_DEPRECATED);
         $client = $collaborators['httpClient'];
         if (!$client instanceof GuzzleClientInterface) {
-            throw new \RuntimeException(sprintf('The value provided with option "HttpClient" must be instance of "%s".', GuzzleClientInterface::class));
+            throw new \RuntimeException(
+                sprintf(
+                    'The value provided with option "HttpClient" must be instance of "%s".',
+                    GuzzleClientInterface::class
+                )
+            );
         }
 
         if (!class_exists(HttplugGuzzle6::class)) {
-            throw new \RuntimeException('You must install "php-http/guzzle6-adapter" to be able to pass a Guzzle6 client with "httpClient" option.');
+            throw new \RuntimeException(
+                'You must install "php-http/guzzle6-adapter" to pass a Guzzle6 client with the "httpClient" option.'
+            );
         }
 
         $this->guzzleClient = $client;

--- a/src/Tool/RequestFactory.php
+++ b/src/Tool/RequestFactory.php
@@ -18,7 +18,6 @@ use Http\Discovery\MessageFactoryDiscovery;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 
-
 /**
  * Used to produce PSR-7 Request instances.
  *

--- a/src/Tool/RequestFactory.php
+++ b/src/Tool/RequestFactory.php
@@ -14,7 +14,10 @@
 
 namespace League\OAuth2\Client\Tool;
 
-use GuzzleHttp\Psr7\Request;
+use Http\Discovery\MessageFactoryDiscovery;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+
 
 /**
  * Used to produce PSR-7 Request instances.
@@ -24,6 +27,11 @@ use GuzzleHttp\Psr7\Request;
 class RequestFactory
 {
     /**
+     * @var \Http\Message\RequestFactory
+     */
+    private $factory;
+
+    /**
      * Creates a PSR-7 Request instance.
      *
      * @param  null|string $method HTTP method for the request.
@@ -32,7 +40,7 @@ class RequestFactory
      * @param  string|resource|StreamInterface $body Message body.
      * @param  string $version HTTP protocol version.
      *
-     * @return Request
+     * @return RequestInterface
      */
     public function getRequest(
         $method,
@@ -41,7 +49,11 @@ class RequestFactory
         $body = null,
         $version = '1.1'
     ) {
-        return new Request($method, $uri, $headers, $body, $version);
+        if (!$this->factory) {
+            $this->factory = MessageFactoryDiscovery::find();
+        }
+
+        return $this->factory->createRequest($method, $uri, $headers, $body, $version);
     }
 
     /**
@@ -70,7 +82,7 @@ class RequestFactory
      * @param  null|string $uri
      * @param  array $options
      *
-     * @return Request
+     * @return RequestInterface
      */
     public function getRequestWithOptions($method, $uri, array $options = [])
     {

--- a/test/src/Grant/GrantTestCase.php
+++ b/test/src/Grant/GrantTestCase.php
@@ -2,7 +2,7 @@
 
 namespace League\OAuth2\Client\Test\Grant;
 
-use GuzzleHttp\ClientInterface;
+use Http\Client\HttpClient;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use League\OAuth2\Client\Token\AccessToken;
@@ -44,7 +44,7 @@ abstract class GrantTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Callback to test access token request parameters.
      *
-     * @return Closure
+     * @return \Closure
      */
     abstract protected function getParamExpectation();
 
@@ -64,8 +64,8 @@ abstract class GrantTestCase extends \PHPUnit_Framework_TestCase
 
         $paramCheck = $this->getParamExpectation();
 
-        $client = m::mock(ClientInterface::class);
-        $client->shouldReceive('send')->with(
+        $client = m::mock(HttpClient::class);
+        $client->shouldReceive('sendRequest')->with(
             $request = m::on(function ($request) use ($paramCheck) {
                 parse_str((string) $request->getBody(), $body);
                 return $paramCheck($body);


### PR DESCRIPTION
This is a backwards compatible implementation of [HTTPlug](http://docs.php-http.org/en/latest/httplug/introduction.html). It provides an abstraction over Guzzle and other libraries sending HTTP messages. Using HTTPlug will comply with the dependency inversion principle.

With this PR we can now allow people using Guzzle5 using this library. This will also future proof us whenever Guzzle7 is released. 
