### PR TITLE
Allow business implementations set their own redirect_uri parameter

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -355,8 +355,13 @@ abstract class AbstractProvider
         // Store the state as it may need to be accessed later on.
         $this->state = $options['state'];
 
+        // Business code layer might set a different redirect_uri parameter
+        // depending on the context, leave it as-is
+        if (!isset($options['redirect_uri'])) {
+            $options['redirect_uri'] = $this->redirectUri;
+        }
+
         $options['client_id'] = $this->clientId;
-        $options['redirect_uri'] = $this->redirectUri;
         $options['state'] = $this->state;
         
         return $options;


### PR DESCRIPTION
I explained my reasons in https://github.com/thephpleague/oauth2-client/issues/542

In some cases, I need to overwrite the redirect_uri parameter depending on the context, but my provider is a singleton in a container, so I need to be able to do it at runtime.