### PR TITLE
Change AbstractProvider getRandomState to only return alphanumeric states

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -27,6 +27,7 @@ use League\OAuth2\Client\Tool\RequestFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use RandomLib\Factory as RandomFactory;
+use RandomLib\Generator as RandomGenerator;
 use UnexpectedValueException;
 
 /**
@@ -302,7 +303,7 @@ abstract class AbstractProvider
             ->getRandomFactory()
             ->getMediumStrengthGenerator();
 
-        return $generator->generateString($length);
+        return $generator->generateString($length, RandomGenerator::CHAR_ALNUM);
     }
 
     /**
@@ -358,7 +359,7 @@ abstract class AbstractProvider
         $options['client_id'] = $this->clientId;
         $options['redirect_uri'] = $this->redirectUri;
         $options['state'] = $this->state;
-        
+
         return $options;
     }
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -64,7 +64,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
             'state' => 'XXX'
         ]));
     }
-    
+
     /**
      * Tests https://github.com/thephpleague/oauth2-client/pull/485
      */
@@ -75,7 +75,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         ]);
         $query = parse_url($url, PHP_URL_QUERY);
         $this->assertNotEmpty($query);
-        
+
         parse_str($query, $params);
         $this->assertArrayHasKey('foo', $params);
         $this->assertSame('BAR', $params['foo']);
@@ -307,7 +307,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $xstate = str_repeat('x', 32);
 
         $generator = m::mock(RandomGenerator::class);
-        $generator->shouldReceive('generateString')->with(32)->times(1)->andReturn($xstate);
+        $generator->shouldReceive('generateString')->with(32, 7)->times(1)->andReturn($xstate);
 
         $factory = m::mock(RandomFactory::class);
         $factory->shouldReceive('getMediumStrengthGenerator')->times(1)->andReturn($generator);


### PR DESCRIPTION
Before, this was using the default character set for `RandomLib/Generator`'s `generateString` which is the base 64 character set that includes "+" and "/". While "/" wasn't causing any problems, using "+" in a URL parameter (e.g. when the OAuth 2 server sends back the state in the query string), the "+" was getting interpreted as a space, which means when a straight string comparison to stored state was being done, it was returning false.

This changes getRandomState to use the `Generator::CHAR_ALNUM` constant as its character set which solves this problem.