### PR TITLE
Add Intercom provider

### DIFF
--- a/README.PROVIDERS.md
+++ b/README.PROVIDERS.md
@@ -55,6 +55,7 @@ Gateway | Composer Package | Maintainer
 [GitLab](https://github.com/omines/oauth2-gitlab) | omines/oauth2-gitlab | [Niels Keurentjes](https://github.com/curry684)
 [Google Nest](https://github.com/JC5/nest-oauth2-provider) | grumpydictator/nest-oauth2-provider | [James Cole](https://github.com/JC5)
 [Harvest](https://github.com/nilesuan/oauth2-harvest) | nilesuan/oauth2-harvest | [Nile Suan](https://github.com/nilesuan)
+[Intercom](https://github.com/intercom/oauth2-intercom) | intercom/oauth2-intercom | [Saša Branković](https://github.com/fox)
 [Imgur](https://github.com/adam-paterson/oauth2-imgur) | adam-paterson/oauth2-imgur | [Adam Paterson](https://github.com/adam-paterson)
 [Keycloak](https://github.com/stevenmaguire/oauth2-keycloak) | stevenmaguire/oauth2-keycloak | [Steven Maguire](https://github.com/stevenmaguire)
 [MailChimp](https://github.com/cfreear/oauth2-mailchimp) | cfreear/oauth2-mailchimp | [Christian Freear](https://github.com/cfreear)


### PR DESCRIPTION
Adds a link to [Intercom provider](https://github.com/intercom/oauth2-intercom).