### PR TITLE
Function to passing additional headers to request

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -521,7 +521,7 @@ abstract class AbstractProvider
     {
         $options = ['headers' => ['content-type' => 'application/x-www-form-urlencoded']];
         if (isset($params['headers']) && is_array($params['headers'])) {
-            $options['headers'] = array_merge($params['headers'], $options['headers']);
+            $options['headers'] = array_merge($options['headers'], $params['headers']);
         }
 
         if ($this->getAccessTokenMethod() === self::METHOD_POST) {

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -519,7 +519,8 @@ abstract class AbstractProvider
      */
     protected function getAccessTokenOptions(array $params)
     {
-        $options = ['headers' => ['content-type' => 'application/x-www-form-urlencoded']];
+        $defaultHeaders = ['content-type' => 'application/x-www-form-urlencoded'];
+        $options = ['headers' => array_merge($defaultHeaders, $params['headers'])];
 
         if ($this->getAccessTokenMethod() === self::METHOD_POST) {
             $options['body'] = $this->getAccessTokenBody($params);

--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -519,8 +519,10 @@ abstract class AbstractProvider
      */
     protected function getAccessTokenOptions(array $params)
     {
-        $defaultHeaders = ['content-type' => 'application/x-www-form-urlencoded'];
-        $options = ['headers' => array_merge($defaultHeaders, $params['headers'])];
+        $options = ['headers' => ['content-type' => 'application/x-www-form-urlencoded']];
+        if (isset($params['headers']) && is_array($params['headers'])) {
+            $options['headers'] = array_merge($params['headers'], $options['headers']);
+        }
 
         if ($this->getAccessTokenMethod() === self::METHOD_POST) {
             $options['body'] = $this->getAccessTokenBody($params);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -670,4 +670,30 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals([], $headers);
     }
+
+    public function testGetAccessTokenOptionsWithNewHeader()
+    {
+        $provider = $this->getAbstractProviderMock();
+        $params = [
+            'headers' => [
+                'ExampleHeader' => 'ExampleContent',
+            ]
+        ];
+
+        $options = $provider->getAccessTokenOptions($params);
+        $this->assertEquals('ExampleContent', $options['headers']['ExampleHeader']);
+    }
+
+    public function testGetAccessTokenOptionsWithContentTypeHeader()
+    {
+        $provider = $this->getAbstractProviderMock();
+        $params = [
+            'headers' => [
+                'content-type' => 'ExampleContentType',
+            ]
+        ];
+
+        $options = $provider->getAccessTokenOptions($params);
+        $this->assertEquals('ExampleContentType', $options['headers']['content-type']);
+    }
 }

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -696,4 +696,15 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $options = $provider->getAccessTokenOptions($params);
         $this->assertEquals('ExampleContentType', $options['headers']['content-type']);
     }
+
+    public function testGetAccessTokenOptionsWithInvalidAdditionalHeaderFormat()
+    {
+        $provider = $this->getAbstractProviderMock();
+        $params = [
+                'content-type' => 'ExampleContentType',
+        ];
+
+        $options = $provider->getAccessTokenOptions($params);
+        $this->assertNotEquals('ExampleContentType', $options['headers']['content-type']);
+    }
 }


### PR DESCRIPTION
It is possible to pass additional headers to getAccessToken request. I implemented that, because I need them for TomTom OAuth2 Authorization: http://developer.tomtom.com/products/sports/mysportscloud/documentation/GetOAuth20Token.

I'll be glad for merging :)
