### PR TITLE
Extract method sendRequest() to new method: getRawResponse()

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -641,12 +641,25 @@ abstract class AbstractProvider
      */
     public function getResponse(RequestInterface $request)
     {
-        $response = $this->sendRequest($request);
+        $response = $this->getRawResponse($request);
         $parsed = $this->parseResponse($response);
 
         $this->checkResponse($response, $parsed);
 
         return $parsed;
+    }
+
+    /**
+     * Sends a request and returns the raw response object.
+     *
+     * @param  RequestInterface $request
+     * @return ResponseInterface
+     */
+    public function getRawResponse(RequestInterface $request)
+    {
+        $response = $this->sendRequest($request);
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
I've extracted method AbstractProvider::sendRequest() from Provider\AbstractProvider::getResponse() to new method AbstractProvider::getRawResponse() because it was impossible to get status code of response. Method getResponse() returns only body of response, but some APIs return only status code, without body.