### PR TITLE
Allow fetching unparsed responses

### DIFF
--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -401,6 +401,24 @@ class AbstractProviderTest extends TestCase
         $provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 
+    public function testGetResponse()
+    {
+        $provider = new MockProvider();
+
+        $request = Phony::mock(RequestInterface::class)->get();
+        $response = Phony::mock(ResponseInterface::class)->get();
+
+        $client = Phony::mock(ClientInterface::class);
+        $client->send->with($request)->returns($response);
+
+        // Run
+        $provider->setHttpClient($client->get());
+        $output = $provider->getResponse($request);
+
+        // Verify
+        $this->assertSame($output, $response);
+    }
+
     public function testAuthenticatedRequestAndResponse()
     {
         $provider = new MockProvider();
@@ -420,7 +438,7 @@ class AbstractProviderTest extends TestCase
 
         // Run
         $provider->setHttpClient($client->get());
-        $result = $provider->getResponse($request);
+        $result = $provider->getParsedResponse($request);
 
         // Verify
         $this->assertSame(['example' => 'response'], $result);


### PR DESCRIPTION
OAuth2 Client providers generally make good API gateways, due to the
inclusion of `getAuthenticatedRequest`. However, the `getResponse`
method always assumes that:

1. The response can be parsed by the provider.
2. The response headers can be discarded.

These two assumptions make it hard to use as a general purpose API
gateway in many situations where content does not come back as JSON or
when headers are required.

Thanks to @rtheunissen for most of this code, which was adapted for
changes made in version 2.x.

Fixes #408