### PR TITLE
Allow expires_in equals 0

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -77,14 +77,11 @@ class AccessToken implements JsonSerializable
         // 'expires_in' since it is defined in RFC6749 Section 5.1.
         // Defer to 'expires' if it is provided instead.
         if (isset($options['expires_in'])) {
-
             if (!is_numeric($options['expires_in'])) {
                 throw new \InvalidArgumentException('expires_in value must be an integer');
             }
 
             $this->expires = $options['expires_in'] != 0 ? time() + $options['expires_in'] : 0;
-
- 
         } elseif (!empty($options['expires'])) {
             // Some providers supply the seconds until expiration rather than
             // the exact timestamp. Take a best guess at which we received.

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -76,8 +76,15 @@ class AccessToken implements JsonSerializable
         // We need to know when the token expires. Show preference to
         // 'expires_in' since it is defined in RFC6749 Section 5.1.
         // Defer to 'expires' if it is provided instead.
-        if (!empty($options['expires_in'])) {
-            $this->expires = time() + ((int) $options['expires_in']);
+        if (isset($options['expires_in'])) {
+
+            if (!is_numeric($options['expires_in'])) {
+                throw new \InvalidArgumentException('expires_in value must be an integer');
+            }
+
+            $this->expires = $options['expires_in'] != 0 ? time() + $options['expires_in'] : 0;
+
+ 
         } elseif (!empty($options['expires'])) {
             // Some providers supply the seconds until expiration rather than
             // the exact timestamp. Take a best guess at which we received.

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -114,6 +114,19 @@ class AccessTokenTest extends TestCase
         $hasExpired = $token->hasExpired();
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidExpiresIn()
+    {
+	 $options = [
+            'access_token' => 'access_token',
+            'expires_in' => 'TEXT',
+         ];
+         $token = $this->getAccessToken($options);
+    }
+
+
     public function testJsonSerializable()
     {
         $options = [


### PR DESCRIPTION
Some services (http://vk.com, no expiration) return "expires_in" equals 0 and no "expires". 
In this case:
!empty($options['expires_in']) == FALSE 
!empty($options['expires']) == FALSE
and expires property remain NULL