### PR TITLE
Fix encoding of generated query strings

### DIFF
--- a/src/Tool/QueryBuilderTrait.php
+++ b/src/Tool/QueryBuilderTrait.php
@@ -28,6 +28,6 @@ trait QueryBuilderTrait
      */
     protected function buildQueryString(array $params)
     {
-        return http_build_query($params, null, '&');
+        return http_build_query($params, null, '&', \PHP_QUERY_RFC3986);
     }
 }

--- a/test/src/Tool/QueryBuilderTraitTest.php
+++ b/test/src/Tool/QueryBuilderTraitTest.php
@@ -19,10 +19,11 @@ class QueryBuilderTraitTest extends PHPUnit_Framework_TestCase
         $params = [
             'a' => 'foo',
             'b' => 'bar',
+            'c' => '+',
         ];
 
         $query = $this->buildQueryString($params);
 
-        $this->assertSame('a=foo&b=bar', $query);
+        $this->assertSame('a=foo&b=bar&c=%2B', $query);
     }
 }


### PR DESCRIPTION
Plus signs should not be encoded as spaces, as this will mangle the
values during server processing.

Fixes #605