### PR TITLE
Add provider redirect tool

### DIFF
--- a/src/Tool/ProviderRedirectTrait.php
+++ b/src/Tool/ProviderRedirectTrait.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace League\OAuth2\Client\Tool;
+
+use GuzzleHttp\Exception\BadResponseException;
+use GuzzleHttp\Psr7\Uri;
+use InvalidArgumentException;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+trait ProviderRedirectTrait
+{
+    /**
+     * Maximum number of times to follow provider initiated redirects
+     *
+     * @var integer
+     */
+    protected $redirectLimit = 2;
+
+    /**
+     * Retrieves a response for a given request and retrieves subsequent
+     * responses, with authorization headers, if a redirect is detected.
+     *
+     * @param  RequestInterface $request
+     * @return ResponseInterface
+     * @throws BadResponseException
+     */
+    protected function followRequestRedirects(RequestInterface $request)
+    {
+        $response = null;
+        $attempts = 0;
+
+        while ($attempts < $this->redirectLimit) {
+            $attempts++;
+            $response = $this->getHttpClient()->send($request, [
+                'allow_redirects' => false
+            ]);
+
+            if ($this->isRedirect($response)) {
+                $redirectUrl = new Uri($response->getHeader('Location')[0]);
+                $request = $request->withUri($redirectUrl);
+            } else {
+                break;
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * Returns the HTTP client instance.
+     *
+     * @return GuzzleHttp\ClientInterface
+     */
+    abstract public function getHttpClient();
+
+    /**
+     * Retrieves current redirect limit.
+     *
+     * @return integer
+     */
+    public function getRedirectLimit()
+    {
+        return $this->redirectLimit;
+    }
+
+    /**
+     * Determines if a given response is a redirect.
+     *
+     * @param  ResponseInterface  $response
+     *
+     * @return boolean
+     */
+    protected function isRedirect(ResponseInterface $response)
+    {
+        $statusCode = $response->getStatusCode();
+
+        return $statusCode > 300 && $statusCode < 400 && $response->hasHeader('Location');
+    }
+
+    /**
+     * Sends a request instance and returns a response instance.
+     *
+     * WARNING: This method does not attempt to catch exceptions caused by HTTP
+     * errors! It is recommended to wrap this method in a try/catch block.
+     *
+     * @param  RequestInterface $request
+     * @return ResponseInterface
+     */
+    public function getResponse(RequestInterface $request)
+    {
+        try {
+            $response = $this->followRequestRedirects($request);
+        } catch (BadResponseException $e) {
+            $response = $e->getResponse();
+        }
+
+        return $response;
+    }
+
+    /**
+     * Updates the redirect limit.
+     *
+     * @param integer $limit
+     * @return League\OAuth2\Client\Provider\AbstractProvider
+     * @throws InvalidArgumentException
+     */
+    public function setRedirectLimit($limit)
+    {
+        if (!is_int($limit)) {
+            throw new InvalidArgumentException('redirectLimit must be an integer.');
+        }
+
+        if ($limit < 1) {
+            throw new InvalidArgumentException('redirectLimit must be greater than or equal to one.');
+        }
+
+        $this->redirectLimit = $limit;
+
+        return $this;
+    }
+}

--- a/test/src/Tool/ProviderRedirectTraitTest.php
+++ b/test/src/Tool/ProviderRedirectTraitTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace League\OAuth2\Client\Test\Tool;
+
+use Eloquent\Phony\Phpunit\Phony;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\BadResponseException;
+use League\OAuth2\Client\Tool\ProviderRedirectTrait;
+use PHPUnit_Framework_TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
+
+class ProviderRedirectTraitTest extends PHPUnit_Framework_TestCase
+{
+    use ProviderRedirectTrait;
+
+    public function getHttpClient()
+    {
+        return $this->httpClient;
+    }
+
+    public function setHttpClient(ClientInterface $httpClient)
+    {
+        $this->httpClient = $httpClient;
+
+        return $this;
+    }
+
+    public function testRedirectLimitDefault()
+    {
+        $this->assertEquals(2, $this->getRedirectLimit());
+    }
+
+    public function testSetRedirectLimit()
+    {
+        $redirectLimit = rand(3, 5);
+        $this->setRedirectLimit($redirectLimit);
+        $this->assertEquals($redirectLimit, $this->getRedirectLimit());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     **/
+    public function testSetRedirectLimitThrowsExceptionWhenNonNumericProvided()
+    {
+        $redirectLimit = 'florp';
+        $this->setRedirectLimit($redirectLimit);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     **/
+    public function testSetRedirectLimitThrowsExceptionWhenZeroProvided()
+    {
+        $redirectLimit = 0;
+        $this->setRedirectLimit($redirectLimit);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     **/
+    public function testSetRedirectLimitThrowsExceptionWhenNegativeIntegerProvided()
+    {
+        $redirectLimit = -10;
+        $this->setRedirectLimit($redirectLimit);
+    }
+
+    public function testClientLimitsRedirectResponse()
+    {
+        $redirectLimit = rand(3, 5);
+        $status = rand(301,399);
+        $redirectUrl = uniqid();
+
+        $request = Phony::mock(RequestInterface::class);
+        $request->withUri->returns($request);
+
+        $response = Phony::mock(ResponseInterface::class);
+        $response->hasHeader->with('Location')->returns(true);
+        $response->getHeader->with('Location')->returns([$redirectUrl]);
+        $response->getStatusCode->returns($status);
+
+        $client = Phony::mock(ClientInterface::class);
+        $client->send->times($redirectLimit)->returns($response->get());
+
+        $this->setHttpClient($client->get())->setRedirectLimit($redirectLimit);
+        $finalResponse = $this->getResponse($request->get());
+    }
+
+    public function testClientLimitsRedirectLoopWhenRedirectNotDetected()
+    {
+        $redirectLimit = rand(3, 5);
+        $status = 200;
+
+        $request = Phony::mock(RequestInterface::class);
+        $request->withUri->returns($request);
+
+        $response = Phony::mock(ResponseInterface::class);
+        $response->hasHeader->with('Location')->returns(true);
+        $response->getStatusCode->returns($status);
+
+        $client = Phony::mock(ClientInterface::class);
+        $client->send->once()->returns($response->get());
+
+        $this->setHttpClient($client->get())->setRedirectLimit($redirectLimit);
+        $finalResponse = $this->getResponse($request->get());
+    }
+
+    public function testClientErrorReturnsResponse()
+    {
+        $status = rand(400, 500);
+        $result = ['foo' => 'bar'];
+
+        $request = Phony::mock(RequestInterface::class);
+        $request->withUri->returns($request);
+
+        $response = Phony::mock(ResponseInterface::class);
+        $response->getStatusCode->returns($status);
+
+        $exception = new BadResponseException('test exception', $request->get(), $response->get());
+
+        $client = Phony::mock(ClientInterface::class);
+        $client->send->throws($exception);
+
+        $this->setHttpClient($client->get());
+        $finalResponse = $this->getResponse($request->get());
+    }
+}


### PR DESCRIPTION
Resolves #600 

> I recently encountered some odd behavior with the Nest API in which the service was returning a response with `307` redirect status and a new url in the `Location` header. 
>
> One user of the `oauth2-nest` client spotted the issue and [began researching on the Nest forums with a thread](https://nestdevelopers.io/t/unauthorized-with-seemingly-valid-access-token/556). That thread surfaced a [similar issue with the `requests` python module](https://github.com/kennethreitz/requests/issues/2949). 
>
> In the end, Nest was sending back a redirect and Guzzle, in its default configuration, was following the redirects without the `Authorization` header and therefore returning an unauthorized response.
>
> I have implemented a solution directly within the `oauth2-nest` client as a trait that seeks to override the `sendRequest` method in the `League\OAuth2\Client\Provider\AbstractProvider`. 
>
> [https://github.com/stevenmaguire/oauth2-nest/blob/master/src/Tool/ProviderRedirectTrait.php](https://github.com/stevenmaguire/oauth2-nest/blob/master/src/Tool/ProviderRedirectTrait.php)
>
> I was on the fence about implementing this solution in the client package because it only seems to cause frustration when using the library to send authenticatedRequests; it does not hinder the obtaining of access tokens, and I do draw a line between the library being an OAuth2 authorization package and not an API wrapper. My instinct was to not implement a solution and help the user understand how they may build a little bit of code themselves to make their own HTTP calls with the AccessToken obtained by the package. I decided to implement the solution in the package because it had a relatively small code footprint and removes a roadblock from the client's "Hello World" demo.
>
> My question for the group here is simple. Do you see value in moving this solution into the core client as an optional tool for other client implementations that _may_ run into this problem?