### PR TITLE
Handling Oauth server internal errors.

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -674,6 +674,14 @@ abstract class AbstractProvider
                 throw $e;
             }
 
+            if ($response->getStatusCode() == 500) {
+                throw new UnexpectedValueException(
+                    'An OAuth server error was encountered that did not contain a JSON body',
+                    0,
+                    $e
+                );
+            }
+
             return $content;
         }
     }


### PR DESCRIPTION
In situation when you OAuth server dies, the web server often gives you
default error 500 page. This page has text/html type, but current
behavior - is to try to parse in anyway.

The problem is: without handling the 500 code on non-json page, you will
get the type error on line 529, which can be hard to debug. So even if
this fix will not enough and you reject it, please at least make some
notice in documentation about handling such errors.

While you auth with Googe, Facebook, etc providers all is usually ok -
they test what they write. But there are lots of sites who provides the
oauth with awful and unstable realisation.