### PR TITLE
Allow depending on either v1 or v2 of random_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.6.0",
         "guzzlehttp/guzzle": "^6.0",
-        "paragonie/random_compat": "^2.0"
+        "paragonie/random_compat": "^1|^2"
     },
     "require-dev": {
         "eloquent/liberator": "^2.0",


### PR DESCRIPTION
Projects that use random_compat v1 are not compatible with oauth2-client. One such example is laravel 5.1 LTS. Since random_compat v1 and v2 are functionally same, it should allow composer decide which version to install based on what other projects use.