### PR TITLE
Fix TypeError thrown because getResourceOwner receives a non-JSON Response

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -766,7 +766,15 @@ abstract class AbstractProvider
 
         $request = $this->getAuthenticatedRequest(self::METHOD_GET, $url, $token);
 
-        return $this->getParsedResponse($request);
+        $response = $this->getParsedResponse($request);
+
+        if (false === is_array($response)) {
+            throw new UnexpectedValueException(
+                'Invalid response received from Authorization Server. Expected JSON.'
+            );
+        }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
The code as written trusts that the OAuth2 server will always return a JSON response and will result in a 500 Exception by the consuming application if it receives any other response.

This fixes that issue but checking the response is what is expected before attemping to call createResourceOwner.