### PR TITLE
Add http basic auth

### DIFF
--- a/src/OptionProvider/HttpBasicAuthOptionProvider.php
+++ b/src/OptionProvider/HttpBasicAuthOptionProvider.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the league/oauth2-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Alex Bilbie <hello@alexbilbie.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth2-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth2-client Packagist
+ * @link https://github.com/thephpleague/oauth2-client GitHub
+ */
+
+namespace League\OAuth2\Client\OptionProvider;
+
+use InvalidArgumentException;
+
+/**
+ * Add http basic auth into access token request options
+ * @link https://tools.ietf.org/html/rfc6749#section-2.3.1
+ */
+class HttpBasicAuthOptionProvider extends PostAuthOptionProvider
+{
+    /**
+     * @inheritdoc
+     */
+    public function getAccessTokenOptions($method, array $params)
+    {
+        if (empty($params['client_id']) || empty($params['client_secret'])) {
+            throw new InvalidArgumentException('clientId and clientSecret are required for http basic auth');
+        }
+
+        $encodedCredentials = base64_encode(sprintf('%s:%s', $params['client_id'], $params['client_secret']));
+        unset($params['client_id'], $params['client_secret']);
+
+        $options = parent::getAccessTokenOptions($method, $params);
+        $options['headers']['Authorization'] = 'Basic ' . $encodedCredentials;
+
+        return $options;
+    }
+}

--- a/src/OptionProvider/OptionProviderInterface.php
+++ b/src/OptionProvider/OptionProviderInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the league/oauth2-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Alex Bilbie <hello@alexbilbie.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth2-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth2-client Packagist
+ * @link https://github.com/thephpleague/oauth2-client GitHub
+ */
+
+namespace League\OAuth2\Client\OptionProvider;
+
+/**
+ * Interface for access token options provider
+ */
+interface OptionProviderInterface
+{
+    /**
+     * Builds request options used for requesting an access token.
+     *
+     * @param string $method
+     * @param  array $params
+     * @return array
+     */
+    public function getAccessTokenOptions($method, array $params);
+}

--- a/src/OptionProvider/PostAuthOptionProvider.php
+++ b/src/OptionProvider/PostAuthOptionProvider.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the league/oauth2-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Alex Bilbie <hello@alexbilbie.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth2-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth2-client Packagist
+ * @link https://github.com/thephpleague/oauth2-client GitHub
+ */
+
+namespace League\OAuth2\Client\OptionProvider;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Tool\QueryBuilderTrait;
+
+/**
+ * Provide options for access token
+ */
+class PostAuthOptionProvider implements OptionProviderInterface
+{
+    use QueryBuilderTrait;
+
+    /**
+     * @inheritdoc
+     */
+    public function getAccessTokenOptions($method, array $params)
+    {
+        $options = ['headers' => ['content-type' => 'application/x-www-form-urlencoded']];
+
+        if ($method === AbstractProvider::METHOD_POST) {
+            $options['body'] = $this->getAccessTokenBody($params);
+        }
+
+        return $options;
+    }
+
+    /**
+     * Returns the request body for requesting an access token.
+     *
+     * @param  array $params
+     * @return string
+     */
+    protected function getAccessTokenBody(array $params)
+    {
+        return $this->buildQueryString($params);
+    }
+}

--- a/test/src/OptionProvider/HttpBasicAuthOptionProviderTest.php
+++ b/test/src/OptionProvider/HttpBasicAuthOptionProviderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace League\OAuth2\Client\Test\OptionProvider;
+
+use League\OAuth2\Client\OptionProvider\HttpBasicAuthOptionProvider;
+use PHPUnit_Framework_TestCase as TestCase;
+use League\OAuth2\Client\Provider\AbstractProvider;
+
+/**
+ * @coversDefaultClass \League\OAuth2\Client\OptionProvider\HttpBasicAuthOptionProvider
+ */
+class HttpBasicAuthOptionProviderTest extends TestCase
+{
+    /**
+     * @var HttpBasicAuthOptionProvider
+     */
+    protected $provider;
+
+    /**
+     * @inheritdoc
+     */
+    protected function setUp()
+    {
+        $this->provider = new HttpBasicAuthOptionProvider();
+    }
+
+    /**
+     * data provider for testGetAccessTokenOptionsException
+     * @return array
+     */
+    public function providerTestGetAccessTokenOptionsException()
+    {
+        return [
+            [['client_id' => 'test']],
+            [['client_secret' => 'test']],
+        ];
+    }
+
+    /**
+     * @covers ::getAccessTokenOptions
+     * @dataProvider providerTestGetAccessTokenOptionsException
+     * @expectedException \InvalidArgumentException
+     * @param array $params
+     */
+    public function testGetAccessTokenOptionsException($params)
+    {
+        $this->provider->getAccessTokenOptions(AbstractProvider::METHOD_POST, $params);
+    }
+
+    /**
+     * @covers ::getAccessTokenOptions
+     */
+    public function testGetAccessTokenOptions()
+    {
+        $options = $this->provider->getAccessTokenOptions(AbstractProvider::METHOD_POST, [
+            'client_id' => 'test',
+            'client_secret' => 'test',
+            'redirect_uri' => 'http://localhost'
+        ]);
+        $this->assertEquals('Basic ' . base64_encode('test:test'), $options['headers']['Authorization']);
+        $this->assertNotContains('client_id', $options['body']);
+        $this->assertNotContains('client_secret', $options['body']);
+    }
+}

--- a/test/src/OptionProvider/PostAuthOptionProviderTest.php
+++ b/test/src/OptionProvider/PostAuthOptionProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace League\OAuth2\Client\Test\OptionProvider;
+
+use League\OAuth2\Client\OptionProvider\PostAuthOptionProvider;
+use PHPUnit_Framework_TestCase as TestCase;
+use League\OAuth2\Client\Provider\AbstractProvider;
+
+/**
+ * @coversDefaultClass League\OAuth2\Client\OptionProvider\PostAuthOptionProvider
+ */
+class PostAuthOptionProviderTest extends TestCase
+{
+    /**
+     * @covers ::getAccessTokenOptions
+     */
+    public function testGetAccessTokenOptions()
+    {
+        $provider = new PostAuthOptionProvider();
+
+        $options = $provider->getAccessTokenOptions(AbstractProvider::METHOD_POST, [
+            'client_id' => 'test',
+            'client_secret' => 'test'
+        ]);
+
+        $this->assertArrayHasKey('headers', $options);
+        $this->assertEquals('client_id=test&client_secret=test', $options['body']);
+    }
+}


### PR DESCRIPTION
Add HTTP basic auth to access token request.

According to [RFC](https://tools.ietf.org/html/rfc6749#section-2.3.1) :

> Including the client credentials in the request-body using the two
   parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
   to directly utilize the HTTP Basic authentication scheme (or other
   password-based HTTP authentication schemes).  The parameters can only
   be transmitted in the request-body and MUST NOT be included in the
   request URI.