### PR TITLE
Change Discord link to actively maintained third-party client

### DIFF
--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -35,7 +35,7 @@ Gateway | Composer Package | Maintainer
 [Coinbase](https://github.com/openclerk/coinbase-oauth2) | openclerk/coinbase-oauth2 | [Openclerk](https://github.com/openclerk)
 [DeviantArt](https://github.com/SeinopSys/oauth2-deviantart) | seinopsys/oauth2-deviantart | [SeinopSys](https://github.com/SeinopSys)
 [DigitalOcean](https://github.com/chrishemmings/oauth2-digitalocean) | chrishemmings/oauth2-digitalocean | [Chris Hemmings](https://github.com/chrishemmings)
-[Discord](https://github.com/teamreflex/oauth2-discord) | team-reflex/oauth2-discord | [David Cole](https://github.com/uniquoooo)
+[Discord](https://github.com/wohali/oauth2-discord-new) | wohali/oauth2-discord-new | [Joan Touzet](https://github.com/wohali)
 [Dribbble](https://github.com/crewlabs/oauth2-dribbble) | crewlabs/oauth2-dribbble | [Crew Labs](https://crew.co/labs)
 [Dropbox](https://github.com/stevenmaguire/oauth2-dropbox) | stevenmaguire/oauth2-dropbox | [Steven Maguire](https://github.com/stevenmaguire)
 [Drupal](https://github.com/chrishemmings/oauth2-drupal) | chrishemmings/oauth2-drupal | [Chris Hemmings](https://github.com/chrishemmings)


### PR DESCRIPTION
Greetings!

Sadly, the [currently linked Discord client](https://github.com/teamreflex/oauth2-discord) appears to be abandoned for over a year. PRs and issues filed on the repo are never addressed by a committer, or are closed without comment. The implementation is also incompatible with the League's 2.x `oauth2-client` releases. Finally, the maintainer's [other major Discord-related PHP project](https://github.com/teamreflex/DiscordPHP) has recently been marked as abandoned.

I have fully re-implemented the Discord provider from scratch, compatible with the 2.x `oauth2-client`. I followed the example of the first-party clients (thanks team!) I have striven to meet the same first-party code quality expectations: tests provide 100% code coverage, Scrutinizer gives the code quality a 10, and there are no lint errors using the same settings as the main `oauth2-client` itself.

Please consider this PR.

I should also like to submit this client for consideration as a potential to be merged into the League's organization, as a first-party client.