### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/test/src/Grant/GrantFactoryTest.php
+++ b/test/src/Grant/GrantFactoryTest.php
@@ -6,7 +6,7 @@ use League\OAuth2\Client\Grant\GrantFactory;
 use League\OAuth2\Client\Grant\AbstractGrant;
 use League\OAuth2\Client\Grant\Exception\InvalidGrantException;
 use League\OAuth2\Client\Test\Grant\Fake as MockGrant;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class GrantFactoryTest extends TestCase
 {

--- a/test/src/Grant/GrantTestCase.php
+++ b/test/src/Grant/GrantTestCase.php
@@ -4,7 +4,7 @@ namespace League\OAuth2\Client\Test\Grant;
 
 use Eloquent\Phony\Phpunit\Phony;
 use GuzzleHttp\ClientInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use League\OAuth2\Client\Token\AccessToken;

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -13,7 +13,7 @@ use League\OAuth2\Client\Grant\GrantFactory;
 use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\RequestFactory;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;

--- a/test/src/Provider/Exception/IdentityProviderException.php
+++ b/test/src/Provider/Exception/IdentityProviderException.php
@@ -3,8 +3,9 @@
 namespace League\OAuth2\Client\Test\Provider\Exception;
 
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use PHPUnit\Framework\TestCase;
 
-class IdentityProviderExceptionTest extends \PHPUnit_Framework_TestCase
+class IdentityProviderExceptionTest extends TestCase
 {
     protected $result;
 

--- a/test/src/Provider/GenericProviderTest.php
+++ b/test/src/Provider/GenericProviderTest.php
@@ -7,7 +7,7 @@ use League\OAuth2\Client\Test\Provider\Generic as MockProvider;
 use League\OAuth2\Client\Provider\GenericProvider;
 use League\OAuth2\Client\Provider\GenericResourceOwner;
 use League\OAuth2\Client\Token\AccessToken;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
 

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -4,7 +4,7 @@ namespace League\OAuth2\Client\Test\Token;
 
 use Eloquent\Phony\Phpunit\Phony;
 use League\OAuth2\Client\Token\AccessToken;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class AccessTokenTest extends TestCase
 {

--- a/test/src/Tool/ArrayAccessorTraitTest.php
+++ b/test/src/Tool/ArrayAccessorTraitTest.php
@@ -3,9 +3,9 @@
 namespace League\OAuth2\Client\Test\Tool;
 
 use League\OAuth2\Client\Tool\ArrayAccessorTrait;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class ArrayAccessorTraitTest extends PHPUnit_Framework_TestCase
+class ArrayAccessorTraitTest extends TestCase
 {
     use ArrayAccessorTrait;
 

--- a/test/src/Tool/ProviderRedirectTraitTest.php
+++ b/test/src/Tool/ProviderRedirectTraitTest.php
@@ -6,11 +6,11 @@ use Eloquent\Phony\Phpunit\Phony;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\BadResponseException;
 use League\OAuth2\Client\Tool\ProviderRedirectTrait;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
 
-class ProviderRedirectTraitTest extends PHPUnit_Framework_TestCase
+class ProviderRedirectTraitTest extends TestCase
 {
     use ProviderRedirectTrait;
 

--- a/test/src/Tool/QueryBuilderTraitTest.php
+++ b/test/src/Tool/QueryBuilderTraitTest.php
@@ -3,9 +3,9 @@
 namespace League\OAuth2\Client\Test\Tool;
 
 use League\OAuth2\Client\Tool\QueryBuilderTrait;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class QueryBuilderTraitTest extends PHPUnit_Framework_TestCase
+class QueryBuilderTraitTest extends TestCase
 {
     use QueryBuilderTrait;
 

--- a/test/src/Tool/RequestFactoryTest.php
+++ b/test/src/Tool/RequestFactoryTest.php
@@ -3,7 +3,7 @@
 namespace League\OAuth2\Client\Test\Tool;
 
 use League\OAuth2\Client\Tool\RequestFactory;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
 class RequestFactoryTest extends TestCase


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).