### PR TITLE
Refactoring tests

### DIFF
--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -653,7 +653,7 @@ class AbstractProviderTest extends TestCase
         $result = ['user_id' => uniqid()];
         $newResult = $provider->prepareAccessTokenResponse($result);
 
-        $this->assertTrue(isset($newResult['resource_owner_id']));
+        $this->assertArrayHasKey('resource_owner_id', $newResult);
         $this->assertEquals($result['user_id'], $newResult['resource_owner_id']);
     }
 
@@ -666,7 +666,7 @@ class AbstractProviderTest extends TestCase
         $result = ['user' => ['id' => uniqid()]];
         $newResult = $provider->prepareAccessTokenResponse($result);
 
-        $this->assertTrue(isset($newResult['resource_owner_id']));
+        $this->assertArrayHasKey('resource_owner_id', $newResult);
         $this->assertEquals($result['user']['id'], $newResult['resource_owner_id']);
     }
 

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -156,7 +156,7 @@ class AccessTokenTest extends TestCase
 
         $values = $token->getValues();
 
-        $this->assertTrue(is_array($values));
+        $this->assertInternalType('array', $values);
         $this->assertArrayHasKey('custom_thing', $values);
         $this->assertSame($options['custom_thing'], $values['custom_thing']);
     }


### PR DESCRIPTION
I've refactored some tests using:
- `assertArrayHasKey` instead of `isset` function;
- `assertInternalType` instead of `is_*` functions.