### PR TITLE
Avoid 'Fatal error: Wrong parameters for Exception' in error response

### DIFF
--- a/src/Provider/GenericProvider.php
+++ b/src/Provider/GenericProvider.php
@@ -212,7 +212,13 @@ class GenericProvider extends AbstractProvider
     {
         if (!empty($data[$this->responseError])) {
             $error = $data[$this->responseError];
-            $code  = $this->responseCode ? $data[$this->responseCode] : 0;
+            if (!is_string($error)) {
+                $error = var_export($error, true);
+            }
+            $code  = $this->responseCode && !empty($data[$this->responseCode])? $data[$this->responseCode] : 0;
+            if (!is_int($code)) {
+                $code = intval($code);
+            }
             throw new IdentityProviderException($error, $code, $data);
         }
     }


### PR DESCRIPTION
Several OAuth2 servers respond with non-standard errors, and the GenericProvider should
be robust in handling them. e.g. I shouldn't get a Fatal error.