### PR TITLE
Remove official project support for HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,18 @@
 language: php
 
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
 matrix:
-    include:
-        - php: 5.6
-        - php: 7.0
-        - php: 7.1
-        - php: 7.2
-        - php: nightly
-        - php: hhvm-3.6
-          sudo: required
-          dist: trusty
-          group: edge
-        - php: hhvm-3.9
-          sudo: required
-          dist: trusty
-          group: edge
-        - php: hhvm-3.12
-          sudo: required
-          dist: trusty
-          group: edge
-        - php: hhvm-3.15
-          sudo: required
-          dist: trusty
-          group: edge
-        - php: hhvm-nightly
-          sudo: required
-          dist: trusty
-          group: edge
-    fast_finish: true
-    allow_failures:
-        - php: nightly
-        - php: hhvm-nightly
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+
+sudo: false
 
 before_install:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This package makes it simple to integrate your application with [OAuth 2.0](http
 [![Latest Version](https://img.shields.io/github/release/thephpleague/oauth2-client.svg?style=flat-square)](https://github.com/thephpleague/oauth2-client/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/thephpleague/oauth2-client/blob/master/LICENSE)
 [![Build Status](https://img.shields.io/travis/thephpleague/oauth2-client/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/oauth2-client)
-[![HHVM Status](https://img.shields.io/hhvm/league/oauth2-client.svg?style=flat-square)](http://hhvm.h4cc.de/package/league/oauth2-client)
 [![Scrutinizer](https://img.shields.io/scrutinizer/g/thephpleague/oauth2-client/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/thephpleague/oauth2-client/)
 [![Coverage Status](https://img.shields.io/coveralls/thephpleague/oauth2-client/master.svg?style=flat-square)](https://coveralls.io/r/thephpleague/oauth2-client?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/league/oauth2-client.svg?style=flat-square)](https://packagist.org/packages/league/oauth2-client)
@@ -30,7 +29,6 @@ The following versions of PHP are supported.
 * PHP 7.0
 * PHP 7.1
 * PHP 7.2
-* HHVM
 
 ## Providers
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,6 @@ League/oauth2-client
 [![Latest Version](https://img.shields.io/github/release/thephpleague/oauth2-client.svg?style=flat-square)](https://github.com/thephpleague/oauth2-client/releases)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/thephpleague/oauth2-client/blob/master/LICENSE)
 [![Build Status](https://img.shields.io/travis/thephpleague/oauth2-client/master.svg?style=flat-square)](https://travis-ci.org/thephpleague/oauth2-client)
-[![HHVM Status](https://img.shields.io/hhvm/league/oauth2-client.svg?style=flat-square)](http://hhvm.h4cc.de/package/league/oauth2-client)
 [![Coverage Status](https://img.shields.io/coveralls/thephpleague/oauth2-client/master.svg?style=flat-square)](https://coveralls.io/r/thephpleague/oauth2-client?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/league/oauth2-client.svg?style=flat-square)](https://packagist.org/packages/league/oauth2-client)
 


### PR DESCRIPTION
This PR removes all HHVM testing on Travis CI and removes mention of official support for HHVM from the README.

While our test suite continues to pass on all HHVM versions we test, many other projects have moved away from official support for HHVM, since HHVM no longer maintains feature parity with PHP 7. When league/oauth2-client no longer supports PHP 5.6, we will need to remove support for HHVM anyway, since we'll potentially be using PHP 7+ features that HHVM does not support.