### PR TITLE
Add @throws tag for better hint when calling getAccessToken()

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -511,6 +511,7 @@ abstract class AbstractProvider
      *
      * @param  mixed $grant
      * @param  array $options
+     * @throws IdentityProviderException
      * @return AccessToken
      */
     public function getAccessToken($grant, array $options = [])
@@ -598,6 +599,7 @@ abstract class AbstractProvider
      * Sends a request and returns the parsed response.
      *
      * @param  RequestInterface $request
+     * @throws IdentityProviderException
      * @return mixed
      */
     public function getParsedResponse(RequestInterface $request)


### PR DESCRIPTION
When I try...catch $this->provider->getAccessToken(), the catched exception IdentityProviderException is hinted "no throw" by the IDE. So, it should be add @throws tag to fix this issue.