### PR TITLE
Throw exception on Non-JSON response from access token request

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -527,6 +527,11 @@ abstract class AbstractProvider
         $params   = $grant->prepareRequestParameters($params, $options);
         $request  = $this->getAccessTokenRequest($params);
         $response = $this->getParsedResponse($request);
+        if (false === is_array($response)) {
+            throw new UnexpectedValueException(
+                'Invalid response received from Authorization Server. Expected JSON.'
+            );
+        }
         $prepared = $this->prepareAccessTokenResponse($response);
         $token    = $this->createAccessToken($prepared, $grant);
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -548,6 +548,24 @@ class AbstractProviderTest extends TestCase
         );
     }
 
+    public function testGetAccessTokenWithNonJsonResponse()
+    {
+        $stream = Phony::mock(StreamInterface::class);
+        $stream->__toString->returns('');
+
+        $response = Phony::mock(ResponseInterface::class);
+        $response->getBody->returns($stream->get());
+        $response->getHeader->with('content-type')->returns('text/plain');
+
+        $client = Phony::mock(ClientInterface::class);
+        $client->send->returns($response->get());
+        $this->provider->setHttpClient($client->get());
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Invalid response received from Authorization Server. Expected JSON.');
+        $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
+
     private function getMethod($class, $name)
     {
         $class = new \ReflectionClass($class);


### PR DESCRIPTION
Otherwise a type error is thrown in the next line. The exception is the same as in `fetchResourceOwnerDetails()`