### PR TITLE
Allow paragonie/random_compat's empty 9.99.99 placeholder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": "^5.6|^7.0",
         "guzzlehttp/guzzle": "^6.0",
-        "paragonie/random_compat": "^1|^2"
+        "paragonie/random_compat": "^1|^2|^9.99"
     },
     "require-dev": {
         "eloquent/liberator": "^2.0",


### PR DESCRIPTION
In order to avoid unnecessarily loading up the vendor directory of PHP 7.x versions with code, the ParagonIE/random_compat library has introduced a [v.9.99.99](https://github.com/paragonie/random_compat#version-99999) that will only install on PHP 7.x and that basically contains no code.

For those of us using PHP 7.x, there's no real reason not to use this version. The Composer dependencies on this project, though, currently hard-code in either version 1 or 2 and don't allow the 9.99 release.

This should solve the problem and allow the dependency to continue to resolve properly on PHP 5.x installations.