### PR TITLE
Add third party PBS provider oauth2-pbs.

### DIFF
--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -77,6 +77,7 @@ Gateway | Composer Package | Maintainer
 [Odnoklassniki](https://packagist.org/packages/aego/oauth2-odnoklassniki) | aego/oauth2-odnoklassniki | [Alexey](https://github.com/rakeev)
 [Optimizely](https://packagist.org/packages/widerfunnel/oauth2-optimizely) | widerfunnel/oauth2-optimizely | [WiderFunnel Labs](https://github.com/WiderFunnel-Labs)
 [PayPal](https://github.com/stevenmaguire/oauth2-paypal) | stevenmaguire/oauth2-paypal | [Steven Maguire](https://github.com/stevenmaguire)
+[PBS](https://github.com/Cascade-Public-Media/oauth2-pbs) | cascadepublicmedia/oauth2-pbs  | [Cascade Public Media](https://github.com/Cascade-Public-Media)
 [Pipedrive](https://github.com/daniti/oauth2-pipedrive) | daniti/oauth2-pipedrive | [Daniele Timo](https://github.com/daniti)
 [Phabricator](https://github.com/ofbeaton/oauth2-phabricator) | ofbeaton/oauth2-phabricator | [Finlay Beaton](https://ofbeaton.com)
 [Pinterest](https://github.com/vantezzen/oauth2-pinterest) | vantezzen/oauth2-pinterest | [vantezzen](https://github.com/vantezzen)


### PR DESCRIPTION
[PBS](https://www.pbs.org/) provides [OAuth2 for member stations](https://docs.pbs.org/display/uua/Integrating+PBS+Account+with+your+website+or+app) to its public account system on PBS.org.