### PR TITLE
Set base href to match deployment

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,2 @@
+baseurl: /
 repository: thephpleague/oauth2-client

--- a/docs/_data/project.yml
+++ b/docs/_data/project.yml
@@ -2,4 +2,4 @@ title: OAuth 2 Client
 tagline: Easy integration with OAuth2 service providers
 description:
 google_analytics_tracking_id:
-base_href:
+base_href: /

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,9 +12,6 @@
     {% if site.data.project.description %}
         <meta name="description" content="{{ site.data.project.description }}">
     {% endif %}
-    {% if site.github.url %}
-        <base href="{{ site.github.url }}">
-    {% endif %}
     {% if site.data.images.favicon %}
         <link rel="icon" type="image/x-icon" href="{{ site.data.images.favicon }}" />
     {% else %}


### PR DESCRIPTION
Base href from `site.github.url` was screwing up built HTML on netlify and local.

Refs #768 