### PR TITLE
Fix league link

### DIFF
--- a/docs/providers/league.md
+++ b/docs/providers/league.md
@@ -12,7 +12,7 @@ support for every OAuth 2 provider without damaging our ability to make this pac
 very high-quality providers into the `league` namespace on a case-by-case basis. You can find some of the criteria on the 
 [third-party providers page](/providers/thirdparty)
 
-There are a [large number of community packages](/providers/thirdparty) that interface with other systems.
+There are a [large number of community packages](docs/providers/thirdparty.md) that interface with other systems.
 
 Installation of any of these packages can be done with composer:
 

--- a/docs/providers/league.md
+++ b/docs/providers/league.md
@@ -10,9 +10,9 @@ Official Providers
 Due to the vast (and ever-growing) number of OAuth 2.0 services that exist, it would be impossible to maintain first-party
 support for every OAuth 2 provider without damaging our ability to make this package the best it can be. Therefore we will only accept
 very high-quality providers into the `league` namespace on a case-by-case basis. You can find some of the criteria on the 
-[third-party providers page](/providers/thirdparty)
+[third-party providers page](/docs/providers/thirdparty.md)
 
-There are a [large number of community packages](docs/providers/thirdparty.md) that interface with other systems.
+There are a [large number of community packages](/docs/providers/thirdparty.md) that interface with other systems.
 
 Installation of any of these packages can be done with composer:
 


### PR DESCRIPTION
refer #770 
but in this page: https://oauth2-client.thephpleague.com/providers/league/

the link is right, will the doc generator will replace the link automatically ? 
if so , my modification is right, or else, it's useless.

