### PR TITLE
Use ArrayAccessor in GenericResourceOwner

### DIFF
--- a/src/Provider/GenericResourceOwner.php
+++ b/src/Provider/GenericResourceOwner.php
@@ -14,11 +14,15 @@
 
 namespace League\OAuth2\Client\Provider;
 
+use League\OAuth2\Client\Tool\ArrayAccessorTrait;
+
 /**
  * Represents a generic resource owner for use with the GenericProvider.
  */
 class GenericResourceOwner implements ResourceOwnerInterface
 {
+    use ArrayAccessorTrait;
+
     /**
      * @var array
      */
@@ -46,7 +50,7 @@ class GenericResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->response[$this->resourceOwnerId];
+        return $this->getValueByKey($this->response, $this->resourceOwnerId);
     }
 
     /**


### PR DESCRIPTION
Allow the `resourceOwnerId` to be specified in more formats, like `user.id`.
This would enable the `GenericProvider` to be used with more OAuth APIs.

Slack, for example, returns the user info in a nested array https://api.slack.com/methods/users.identity#response

By accepting this PR, the Slack OAuth and others can be used with the `GenericProvider`.