### PR TITLE
add more detail on the unit of time for the access token expiration

### DIFF
--- a/src/Token/AccessTokenInterface.php
+++ b/src/Token/AccessTokenInterface.php
@@ -34,7 +34,7 @@ interface AccessTokenInterface extends JsonSerializable
     public function getRefreshToken();
 
     /**
-     * Returns the expiration timestamp, if defined.
+     * Returns the expiration timestamp in seconds, if defined.
      *
      * @return integer|null
      */


### PR DESCRIPTION
I constantly find myself visiting the rfc to determine if its seconds or milliseconds.