### PR TITLE
Allow guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require": {
         "php": "^5.6|^7.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "paragonie/random_compat": "^1|^2|^9.99"
     },
     "require-dev": {


### PR DESCRIPTION
Hi,

We have recently tagged a new version 7 of guzzle.

https://github.com/guzzle/guzzle/releases/tag/7.0.0

🎉 