### PR TITLE
Changed signature of methods in AbstractProvider.php

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -289,7 +289,7 @@ abstract class AbstractProvider
      * @param AccessToken $token
      * @return string
      */
-    abstract public function getResourceOwnerDetailsUrl(AccessToken $token);
+    abstract public function getResourceOwnerDetailsUrl(AccessTokenInterface $token);
 
     /**
      * Returns a new random string to use as the state parameter in an
@@ -754,7 +754,7 @@ abstract class AbstractProvider
      * @param  AccessToken $token
      * @return ResourceOwnerInterface
      */
-    abstract protected function createResourceOwner(array $response, AccessToken $token);
+    abstract protected function createResourceOwner(array $response, AccessTokenInterface $token);
 
     /**
      * Requests and returns the resource owner of given access token.
@@ -762,7 +762,7 @@ abstract class AbstractProvider
      * @param  AccessToken $token
      * @return ResourceOwnerInterface
      */
-    public function getResourceOwner(AccessToken $token)
+    public function getResourceOwner(AccessTokenInterface $token)
     {
         $response = $this->fetchResourceOwnerDetails($token);
 
@@ -775,7 +775,7 @@ abstract class AbstractProvider
      * @param  AccessToken $token
      * @return mixed
      */
-    protected function fetchResourceOwnerDetails(AccessToken $token)
+    protected function fetchResourceOwnerDetails(AccessTokenInterface $token)
     {
         $url = $this->getResourceOwnerDetailsUrl($token);
 


### PR DESCRIPTION
- Abstract methods in AbstractProvider.php should use
AccessTokenInterface instead of the concrete AccessToken class provided by League.

- See: https://github.com/thephpleague/oauth2-client/issues/897