### PR TITLE
Exclude redirect_uri param from refresh_token requests.

### DIFF
--- a/src/Grant/RefreshToken.php
+++ b/src/Grant/RefreshToken.php
@@ -38,4 +38,14 @@ class RefreshToken extends AbstractGrant
             'refresh_token',
         ];
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function prepareRequestParameters(array $defaults, array $options)
+    {
+        unset($defaults['redirect_uri']);
+
+        return parent::prepareRequestParameters($defaults, $options);
+    }
 }


### PR DESCRIPTION
I ran into this issue with a OAuth2 provider rejecting my refresh_token request as it included the redirect_uri parameter.