### PR TITLE
.gitignore: ignore PHPUnit cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ testing/
 nbproject/private/
 test/log
 build
+/.phpunit.result.cache


### PR DESCRIPTION
As of PHPUnit 8, PHPUnit will generate a `.phpunit.result.cache` file, which shouldn't be committed.