### PR TITLE
GH Actions: lint against all supported PHP versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,6 +16,14 @@ jobs:
   lint:
     name: "Lint"
     runs-on: "ubuntu-latest"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+
+    continue-on-error: ${{ matrix.php-version == '8.1' }}
+
     steps:
       - uses: "actions/checkout@v2"
       - uses: "shivammathur/setup-php@v2"


### PR DESCRIPTION
For now, linting against PHP 8.1 is set to be allowed to fail. This should be turned off once PHP 8.1 has been released in 4/5 weeks time.

Optionally, the `test` workflow could be made dependent on the `lint` workflow, so it won't run unnecessarily.