### PR TITLE
Composer: update various dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         "paragonie/random_compat": "^1 || ^2 || ^9.99"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3",
-        "php-parallel-lint/php-parallel-lint": "^1.2",
-        "phpunit/phpunit": "^5.7 || ^6.0 || ^9.3",
+        "mockery/mockery": "^1.3.5",
+        "php-parallel-lint/php-parallel-lint": "^1.3.1",
+        "phpunit/phpunit": "^5.7 || ^6.0 || ^9.5",
         "squizlabs/php_codesniffer": "^2.3 || ^3.0"
     },
     "keywords": [


### PR DESCRIPTION
While, the version constraints work with _minimum_ versions, I'd recommend upping those minimum versions of various CI tools to ensure that PHP 8.1 compatible versions of the tooling will be installed.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
* https://github.com/mockery/mockery/releases
* https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-9.5.md