### PR TITLE
 PHP 8.1: fix deprecation warnings / http_build_query()

### DIFF
--- a/src/Tool/QueryBuilderTrait.php
+++ b/src/Tool/QueryBuilderTrait.php
@@ -28,6 +28,6 @@ trait QueryBuilderTrait
      */
     protected function buildQueryString(array $params)
     {
-        return http_build_query($params, null, '&', \PHP_QUERY_RFC3986);
+        return http_build_query($params, '', '&', \PHP_QUERY_RFC3986);
     }
 }


### PR DESCRIPTION
This fixes an issue with a call to the PHP native `http_build_query()` function, the second parameter of which is the _optional_ `$numeric_prefix` parameter which expects a `string`.

A parameter being optional, however, does not automatically make it nullable.

As of PHP 8.1, passing `null` to a non-nullable PHP native function will generate a deprecation notice.
In this case, this function call yielded a `http_build_query(): Passing null to parameter composer#2 ($numeric_prefix) of type string is deprecated` notice.

Changing the `null` to an empty string fixes this without BC-break.

Fixes nearly all deprecation warnings found when running the tests.

Refs:
* https://www.php.net/manual/en/function.http-build-query.php
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg