### PR TITLE
Sets default scope separator to space in line with the RFC, breaking most existing providers. You should not merge this pr.

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -319,11 +319,11 @@ abstract class AbstractProvider
      * Returns the string that should be used to separate scopes when building
      * the URL for requesting an access token.
      *
-     * @return string Scope separator, defaults to ','
+     * @return string Scope separator, defaults to ' ' per rfc6749 section 3.3.
      */
     protected function getScopeSeparator()
     {
-        return ',';
+        return ' ';
     }
 
     /**


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc6749#section-3.3

> The authorization and token endpoints allow the client to specify the
   scope of the access request using the "scope" request parameter.  In
   turn, the authorization server uses the "scope" response parameter to
   inform the client of the scope of the access token issued.
> 
> The value of the scope parameter is expressed as a list of **space-
   delimited, case-sensitive strings.**  The strings are defined by the
   authorization server.  If the value contains multiple space-delimited
   strings, their order does not matter, and each string adds an
   additional access range to the requested scope.
> 
>     scope       = scope-token *( SP scope-token )
>     scope-token = 1*( %x21 / %x23-5B / %x5D-7E )

### You should not merge this pr.

~~Somebody with more time than me who wanted to address this shortfalling, could code it such that the generic provider takes this as an argument/property that can be set on user code that uses the generic provider.~~ Already a thing

Thank you and good day.