### PR TITLE
Docs: Fix state check example if session variable is not set

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,7 +42,7 @@ if (!isset($_GET['code'])) {
     exit;
 
 // Check given state against previously stored one to mitigate CSRF attack
-} elseif (empty($_GET['state']) || (isset($_SESSION['oauth2state']) && $_GET['state'] !== $_SESSION['oauth2state'])) {
+} elseif (empty($_GET['state']) || empty($_SESSION['oauth2state']) || $_GET['state'] !== $_SESSION['oauth2state']) {
 
     if (isset($_SESSION['oauth2state'])) {
         unset($_SESSION['oauth2state']);


### PR DESCRIPTION
The state check in the [Basic Usage](https://oauth2-client.thephpleague.com/usage/) example will only fail if the session variable is set. If an attacker uses a fresh session with the "oauth2state" session variable unset, the check would pass. Even worse if the attacker uses a random state and the check fails, the state variable will be unset in the next line. Then a second request would just pass.