### PR TITLE
Add smolblog/oauth2-twitter as a twitter library

### DIFF
--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -124,6 +124,7 @@ Gateway | Composer Package | Maintainer
 [Twinfield](https://github.com/php-twinfield/twinfield) | php-twinfield/twinfield | [Mollie B.V.](https://github.com/mollie)
 [Twitch.tv](https://github.com/tpavlek/oauth2-twitch) | depotwarehouse/oauth2-twitch | [Troy Pavlek](https://github.com/tpavlek)
 [Twitch.tv (New API Helix)](https://github.com/vertisan/oauth2-twitch-helix) | vertisan/oauth2-twitch-helix | [Paweł Farys](https://github.com/vertisan)
+[Twitter](https://github.com/smolblog/oauth2-twitter) | smolblog/oauth2-twitter | [Evan Hildreth](https://github.com/oddevan)
 [Uber](https://github.com/stevenmaguire/oauth2-uber) | stevenmaguire/oauth2-uber | [Steven Maguire](https://github.com/stevenmaguire)
 [Unsplash](https://github.com/hughbertd/oauth2-unsplash) | hughbertd/oauth2-unsplash | [Hugh Downer](https://github.com/hughbertd)
 [Untappd](https://github.com/shadowhand/oauth2-untappd) | shadowhand/oauth2-untappd | [Woody Gilk](https://github.com/shadowhand)


### PR DESCRIPTION
Adding the [smolblog/oauth2-twitter](https://github.com/smolblog/oauth2-twitter) library as a usable Twitter library.

Feedback on the library is welcome, and I am happy to make any changes needed to be accepted to this list.

Thanks again for all y'all do!