### PR TITLE
Fix import, method and minor refactor

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -541,9 +541,7 @@ abstract class AbstractProvider
             );
         }
         $prepared = $this->prepareAccessTokenResponse($response);
-        $token    = $this->createAccessToken($prepared, $grant);
-
-        return $token;
+        return $this->createAccessToken($prepared);
     }
 
     /**
@@ -738,10 +736,9 @@ abstract class AbstractProvider
      * additional context.
      *
      * @param  array $response
-     * @param  AbstractGrant $grant
      * @return AccessTokenInterface
      */
-    protected function createAccessToken(array $response, AbstractGrant $grant)
+    protected function createAccessToken(array $response)
     {
         return new AccessToken($response);
     }

--- a/src/Tool/RequestFactory.php
+++ b/src/Tool/RequestFactory.php
@@ -15,6 +15,7 @@
 namespace League\OAuth2\Client\Tool;
 
 use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * Used to produce PSR-7 Request instances.
@@ -23,6 +24,8 @@ use GuzzleHttp\Psr7\Request;
  */
 class RequestFactory
 {
+    const DEFAULT_PROTOCOL_VERSION = '1.1';
+
     /**
      * Creates a PSR-7 Request instance.
      *
@@ -39,7 +42,7 @@ class RequestFactory
         $uri,
         array $headers = [],
         $body = null,
-        $version = '1.1'
+        $version = self::DEFAULT_PROTOCOL_VERSION
     ) {
         return new Request($method, $uri, $headers, $body, $version);
     }
@@ -57,7 +60,7 @@ class RequestFactory
         $defaults = [
             'headers' => [],
             'body'    => null,
-            'version' => '1.1',
+            'version' => self::DEFAULT_PROTOCOL_VERSION,
         ];
 
         return array_merge($defaults, $options);


### PR DESCRIPTION
The `docs/` directory is what powers the website [oauth2-client.thephpleague.com](https://oauth2-client.thephpleague.com/). Modifying links to work in the Github file browser will break the website. Please do not open a new Pull Request to "fix the broken documentation links"; they will be promptly closed.
