### PR TITLE
docs: add koalati/oauth2-webflow to list of providers

### DIFF
--- a/docs/providers/thirdparty.md
+++ b/docs/providers/thirdparty.md
@@ -145,6 +145,7 @@ Gateway | Composer Package | Maintainer
 [Vkontakte](https://github.com/j4k/oauth2-vkontakte) | j4k/oauth2-vkontakte | [Jack W](https://github.com/j4k)
 [Withings](https://github.com/waytohealth/oauth2-withings) | waytohealth/oauth2-withings | [Way to Health](https://github.com/waytohealth)
 [WordPress](https://github.com/krombox/oauth2-wordpress) | krombox/oauth2-wordpress | [Roman Kapustian](https://github.com/krombox)
+[Webflow](https://github.com/koalatiapp/oauth2-webflow) | koalati/oauth2-webflow | [Koalati](https://github.com/koalatiapp)
 [Wechat](https://github.com/oakhope/oauth2-wechat) | oakhope/oauth2-wechat | [Benji Wang](https://github.com/oakhope)
 [WeCounsel](https://github.com/stevenmaguire/oauth2-wecounsel) | stevenmaguire/oauth2-wecounsel | [Steven Maguire](https://github.com/stevenmaguire)
 [Wrike](https://github.com/michaelKaefer/oauth2-wrike) | michaelkaefer/oauth2-wrike | [Michael Käfer](https://github.com/michaelKaefer)


### PR DESCRIPTION
This PR adds a link to the new [`koalati/oauth2-webflow`](https://github.com/koalatiapp/oauth2-webflow) OAuth 2.0 provider for [Webflow](https://webflow.com/).