### PR TITLE
Support setting refreshToken

### DIFF
--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -172,6 +172,14 @@ class AccessToken implements AccessTokenInterface, ResourceOwnerAccessTokenInter
     /**
      * @inheritdoc
      */
+    public function setRefreshToken($refreshToken)
+    {
+        $this->refreshToken = $refreshToken;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function getExpires()
     {
         return $this->expires;

--- a/src/Token/AccessToken.php
+++ b/src/Token/AccessToken.php
@@ -22,7 +22,7 @@ use RuntimeException;
  *
  * @link http://tools.ietf.org/html/rfc6749#section-1.4 Access Token (RFC 6749, §1.4)
  */
-class AccessToken implements AccessTokenInterface, ResourceOwnerAccessTokenInterface
+class AccessToken implements AccessTokenInterface, ResourceOwnerAccessTokenInterface, SettableRefreshTokenInterface
 {
     /**
      * @var string

--- a/src/Token/ResourceOwnerAccessTokenInterface.php
+++ b/src/Token/ResourceOwnerAccessTokenInterface.php
@@ -14,7 +14,7 @@
 
 namespace League\OAuth2\Client\Token;
 
-interface ResourceOwnerAccessTokenInterface
+interface ResourceOwnerAccessTokenInterface extends AccessTokenInterface
 {
     /**
      * Returns the resource owner identifier, if defined.

--- a/src/Token/ResourceOwnerAccessTokenInterface.php
+++ b/src/Token/ResourceOwnerAccessTokenInterface.php
@@ -14,7 +14,7 @@
 
 namespace League\OAuth2\Client\Token;
 
-interface ResourceOwnerAccessTokenInterface extends AccessTokenInterface
+interface ResourceOwnerAccessTokenInterface
 {
     /**
      * Returns the resource owner identifier, if defined.

--- a/src/Token/SettableRefreshTokenInterface.php
+++ b/src/Token/SettableRefreshTokenInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the league/oauth2-client library
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Copyright (c) Alex Bilbie <hello@alexbilbie.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ * @link http://thephpleague.com/oauth2-client/ Documentation
+ * @link https://packagist.org/packages/league/oauth2-client Packagist
+ * @link https://github.com/thephpleague/oauth2-client GitHub
+ */
+
+namespace League\OAuth2\Client\Token;
+
+interface SettableRefreshTokenInterface extends AccessTokenInterface
+{
+    /**
+     * Sets the refresh token.
+     *
+     * @param  string $refreshToken
+     * @return void
+     */
+    public function setRefreshToken($refreshToken);
+}

--- a/src/Token/SettableRefreshTokenInterface.php
+++ b/src/Token/SettableRefreshTokenInterface.php
@@ -17,9 +17,9 @@ namespace League\OAuth2\Client\Token;
 interface SettableRefreshTokenInterface extends AccessTokenInterface
 {
     /**
-     * Sets the refresh token.
+     * Sets or replaces the refresh token with the provided refresh token.
      *
-     * @param  string $refreshToken
+     * @param string $refreshToken
      * @return void
      */
     public function setRefreshToken($refreshToken);

--- a/src/Token/SettableRefreshTokenInterface.php
+++ b/src/Token/SettableRefreshTokenInterface.php
@@ -14,7 +14,7 @@
 
 namespace League\OAuth2\Client\Token;
 
-interface SettableRefreshTokenInterface extends AccessTokenInterface
+interface SettableRefreshTokenInterface
 {
     /**
      * Sets or replaces the refresh token with the provided refresh token.

--- a/test/src/Token/AccessTokenTest.php
+++ b/test/src/Token/AccessTokenTest.php
@@ -123,6 +123,23 @@ class AccessTokenTest extends TestCase
         self::tearDownForBackwardsCompatibility();
     }
 
+    public function testSetRefreshToken()
+    {
+        $refreshToken = 'refresh_token';
+
+        $options = [
+            'access_token' => 'access_token',
+        ];
+
+        $token = $this->getAccessToken($options);
+
+        $token->setRefreshToken($refreshToken);
+
+        $this->assertEquals($refreshToken, $token->getRefreshToken());
+
+        self::tearDownForBackwardsCompatibility();
+    }
+
     public function testHasNotExpiredWhenPropertySetInFuture()
     {
         $options = [


### PR DESCRIPTION
In the cases where the refresh token isn't included in the response when using it to refresh an access token, it's often necessary to persist the original refresh token for later use.  When this happens it's convenient to store the refresh token in the `AccessToken` object as it was originally.

However, because `AccessToken::$refreshToken` is a protected property it's not possible to assign this value directly.  Implementing `AccessToken::setRefreshToken()` allows the refresh token to be set and stored along with the `AccessToken` object.

The workaround I've found is to serialize the `AccessToken` object to JSON, add the refresh token, then reinstantiate a new `AccessToken` object.  It would be great if this wasn't necessary.

Building the functionality directly into the library to automatically carry over the refresh token would be great (as suggested in #658), but I'm not sure if that behavior would apply to all cases.  It might cause confusion if it was intentionally omitted from the response because it's no longer valid.

Related to https://github.com/thephpleague/oauth2-client/issues/658
