### PR TITLE
Improve type of $options parameter in Provider\AbstractProvider::getAccessToken()

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -611,8 +611,8 @@ abstract class AbstractProvider
     /**
      * Requests an access token using a specified grant and option set.
      *
-     * @param  mixed $grant
-     * @param  array $options
+     * @param  mixed                $grant
+     * @param  array<string, mixed> $options
      * @throws IdentityProviderException
      * @return AccessTokenInterface
      */


### PR DESCRIPTION
Avoid contravariance issue on high levels of static analysis tools for children classes