### PR TITLE
Fix tests by returning array from PSR7's ResponseInterface::getHeader()

### DIFF
--- a/test/src/Grant/GrantTestCase.php
+++ b/test/src/Grant/GrantTestCase.php
@@ -65,7 +65,7 @@ abstract class GrantTestCase extends TestCase
             ->shouldReceive('getHeader')
             ->once()
             ->with('content-type')
-            ->andReturn('application/json');
+            ->andReturn(['application/json']);
 
         /** @var ClientInterface & MockInterface $client */
         $client = Mockery::spy(ClientInterface::class)->makePartial();

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -213,7 +213,7 @@ class AbstractProviderTest extends TestCase
             ->shouldReceive('getHeader')
             ->once()
             ->with('content-type')
-            ->andReturn('application/json');
+            ->andReturn(['application/json']);
 
 
         $client = Mockery::spy(ClientInterface::class, [
@@ -262,7 +262,7 @@ class AbstractProviderTest extends TestCase
         $response
             ->shouldReceive('getHeader')
             ->with('content-type')
-            ->andReturn('text/html');
+            ->andReturn(['text/html']);
 
         $client = Mockery::mock(ClientInterface::class, [
             'send' => $response,
@@ -378,7 +378,7 @@ class AbstractProviderTest extends TestCase
             ->shouldReceive('getHeader')
             ->once()
             ->with('content-type')
-            ->andReturn('application/json');
+            ->andReturn(['application/json']);
 
         $client = Mockery::spy(ClientInterface::class, [
             'send' => $response,
@@ -474,7 +474,7 @@ class AbstractProviderTest extends TestCase
             ->shouldReceive('getHeader')
             ->once()
             ->with('content-type')
-            ->andReturn('application/json');
+            ->andReturn(['application/json']);
 
         $client = Mockery::spy(ClientInterface::class, [
             'send' => $response,
@@ -532,7 +532,7 @@ class AbstractProviderTest extends TestCase
         $response
             ->shouldReceive('getHeader')
             ->with('content-type')
-            ->andReturn('application/json');
+            ->andReturn(['application/json']);
 
         $client = Mockery::mock(ClientInterface::class);
         $client
@@ -579,7 +579,7 @@ class AbstractProviderTest extends TestCase
         $response
             ->shouldReceive('getHeader')
             ->with('content-type')
-            ->andReturn('application/json');
+            ->andReturn(['application/json']);
 
         $client = Mockery::mock(ClientInterface::class);
         $client
@@ -647,7 +647,7 @@ class AbstractProviderTest extends TestCase
             ->shouldReceive('getHeader')
             ->once()
             ->with('content-type')
-            ->andReturn('application/json');
+            ->andReturn(['application/json']);
 
         $client = Mockery::spy(ClientInterface::class, [
             'send' => $response,
@@ -686,7 +686,7 @@ class AbstractProviderTest extends TestCase
         $response
             ->shouldReceive('getHeader')
             ->with('content-type')
-            ->andReturn('text/plain');
+            ->andReturn(['text/plain']);
 
         $client = Mockery::mock(ClientInterface::class, [
             'send' => $response,
@@ -740,12 +740,12 @@ class AbstractProviderTest extends TestCase
 
         $response = Mockery::mock(ResponseInterface::class, [
             'getBody' => $stream,
-            'getStatusCode' => $statusCode,
+            'getStatusCode' => $statusCode,s
         ]);
         $response
             ->shouldReceive('getHeader')
             ->with('content-type')
-            ->andReturn($type);
+            ->andReturn([$type]);
 
         $method = $this->getMethod(AbstractProvider::class, 'parseResponse');
         $result = $method->invoke($this->getMockProvider(), $response);

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -740,7 +740,7 @@ class AbstractProviderTest extends TestCase
 
         $response = Mockery::mock(ResponseInterface::class, [
             'getBody' => $stream,
-            'getStatusCode' => $statusCode,s
+            'getStatusCode' => $statusCode,
         ]);
         $response
             ->shouldReceive('getHeader')


### PR DESCRIPTION
PSR-7's `ResponseInterface` [returns an array](https://github.com/php-fig/http-message/blob/master/src/MessageInterface.php#L90-L94) from `getHeader` and not a string. This PR updates tests to return an array as well.