### PR TITLE
add missing exception annotations

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -405,6 +405,7 @@ abstract class AbstractProvider
      *
      * @param  array $options
      * @return array Authorization parameters
+     * @throws InvalidArgumentException
      */
     protected function getAuthorizationParameters(array $options)
     {
@@ -476,6 +477,7 @@ abstract class AbstractProvider
      *
      * @param  array $options
      * @return string Authorization URL
+     * @throws InvalidArgumentException
      */
     public function getAuthorizationUrl(array $options = [])
     {
@@ -492,6 +494,7 @@ abstract class AbstractProvider
      * @param  array $options
      * @param  callable|null $redirectHandler
      * @return mixed
+     * @throws InvalidArgumentException
      */
     public function authorize(
         array $options = [],
@@ -613,8 +616,9 @@ abstract class AbstractProvider
      *
      * @param  mixed                $grant
      * @param  array<string, mixed> $options
-     * @throws IdentityProviderException
      * @return AccessTokenInterface
+     * @throws IdentityProviderException
+     * @throws UnexpectedValueException
      */
     public function getAccessToken($grant, array $options = [])
     {
@@ -719,8 +723,9 @@ abstract class AbstractProvider
      * Sends a request and returns the parsed response.
      *
      * @param  RequestInterface $request
-     * @throws IdentityProviderException
      * @return mixed
+     * @throws IdentityProviderException
+     * @throws UnexpectedValueException
      */
     public function getParsedResponse(RequestInterface $request)
     {
@@ -868,6 +873,8 @@ abstract class AbstractProvider
      *
      * @param  AccessToken $token
      * @return ResourceOwnerInterface
+     * @throws IdentityProviderException
+     * @throws UnexpectedValueException
      */
     public function getResourceOwner(AccessToken $token)
     {
@@ -881,6 +888,8 @@ abstract class AbstractProvider
      *
      * @param  AccessToken $token
      * @return mixed
+     * @throws IdentityProviderException
+     * @throws UnexpectedValueException
      */
     protected function fetchResourceOwnerDetails(AccessToken $token)
     {


### PR DESCRIPTION
This PR adds missing _@throws_ annotations to method doc blocks in the AbstractProvider class, ensuring all thrown exceptions are properly documented.

**Related Issue**
Fixes [Issue #880](https://github.com/thephpleague/oauth2-client/issues/880) by improving PHPDoc accuracy, enhancing developer experience, and supporting static analysis tools.

**Changes**
Added @throws annotations for all undocumented exceptions in method doc blocks.
Verified annotations match the exceptions thrown.