### PR TITLE
Revert BC break by only providing scopes in access token when set in options

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -624,11 +624,7 @@ abstract class AbstractProvider
     {
         $grant = $this->verifyGrant($grant);
 
-        if (empty($options['scope'])) {
-            $options['scope'] = $this->getDefaultScopes();
-        }
-
-        if (is_array($options['scope'])) {
+        if (isset($options['scope']) && is_array($options['scope'])) {
             $separator = $this->getScopeSeparator();
             $options['scope'] = implode($separator, $options['scope']);
         }

--- a/test/src/Grant/PasswordTest.php
+++ b/test/src/Grant/PasswordTest.php
@@ -20,8 +20,7 @@ class PasswordTest extends GrantTestCase
             return !empty($body['grant_type'])
                 && $body['grant_type'] === 'password'
                 && !empty($body['username'])
-                && !empty($body['password'])
-                && !empty($body['scope']);
+                && !empty($body['password']);
         };
     }
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -697,7 +697,7 @@ class AbstractProviderTest extends TestCase
             ->once()
             ->with(
                 ['client_id' => 'mock_client_id', 'client_secret' => 'mock_secret', 'redirect_uri' => 'none'],
-                ['code' => 'mock_authorization_code', 'scope' => 'test']
+                ['code' => 'mock_authorization_code', 'scope' => 'foo,bar']
             )
             ->andReturn([]);
 
@@ -723,7 +723,7 @@ class AbstractProviderTest extends TestCase
         ]);
 
         $provider->setHttpClient($client);
-        $token = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code', 'scope' => 'test']);
+        $token = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code', 'scope' => ['foo', 'bar']]);
 
         $this->assertInstanceOf(AccessTokenInterface::class, $token);
 

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -632,7 +632,7 @@ class AbstractProviderTest extends TestCase
             ->once()
             ->with(
                 ['client_id' => 'mock_client_id', 'client_secret' => 'mock_secret', 'redirect_uri' => 'none'],
-                ['code' => 'mock_authorization_code', 'scope' => 'test']
+                ['code' => 'mock_authorization_code']
             )
             ->andReturn([]);
 
@@ -659,6 +659,71 @@ class AbstractProviderTest extends TestCase
 
         $provider->setHttpClient($client);
         $token = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code']);
+
+        $this->assertInstanceOf(AccessTokenInterface::class, $token);
+
+        $this->assertSame($raw_response['resource_owner_id'], $token->getResourceOwnerId());
+        $this->assertSame($raw_response['access_token'], $token->getToken());
+        $this->assertSame($raw_response['expires'], $token->getExpires());
+
+        $client
+            ->shouldHaveReceived('send')
+            ->once()
+            ->withArgs(function ($request) use ($provider) {
+                return $request->getMethod() === $provider->getAccessTokenMethod()
+                    && (string) $request->getUri() === $provider->getBaseAccessTokenUrl([]);
+            });
+    }
+
+    /**
+     * @dataProvider getAccessTokenMethodProvider
+     */
+    #[DataProvider('getAccessTokenMethodProvider')]
+    public function testGetAccessTokenWithScope($method)
+    {
+        $provider = new MockProvider([
+            'clientId' => 'mock_client_id',
+            'clientSecret' => 'mock_secret',
+            'redirectUri' => 'none',
+        ]);
+
+        $provider->setAccessTokenMethod($method);
+
+        $raw_response = ['access_token' => 'okay', 'expires' => time() + 3600, 'resource_owner_id' => 3];
+
+        $grant = Mockery::mock(AbstractGrant::class);
+        $grant
+            ->shouldReceive('prepareRequestParameters')
+            ->once()
+            ->with(
+                ['client_id' => 'mock_client_id', 'client_secret' => 'mock_secret', 'redirect_uri' => 'none'],
+                ['code' => 'mock_authorization_code', 'scope' => 'test']
+            )
+            ->andReturn([]);
+
+        $stream = Mockery::mock(StreamInterface::class);
+        $stream
+            ->shouldReceive('__toString')
+            ->once()
+            ->andReturn(json_encode($raw_response));
+
+        $response = Mockery::mock(ResponseInterface::class);
+        $response
+            ->shouldReceive('getBody')
+            ->once()
+            ->andReturn($stream);
+        $response
+            ->shouldReceive('getHeader')
+            ->once()
+            ->with('content-type')
+            ->andReturn(['application/json']);
+
+        $client = Mockery::spy(ClientInterface::class, [
+            'send' => $response,
+        ]);
+
+        $provider->setHttpClient($client);
+        $token = $provider->getAccessToken($grant, ['code' => 'mock_authorization_code', 'scope' => 'test']);
 
         $this->assertInstanceOf(AccessTokenInterface::class, $token);
 


### PR DESCRIPTION
Partially reverts #1030 
This will still allow to set a `scope` on the access token as array and format it properly, but it will not add the default scopes by default.

Setting the scope in the access token request is optional according to https://www.rfc-editor.org/rfc/rfc6749#section-3.3
In practice it seems to limit the scopes that are set in the authorization flow to a subset of the original scopes. But this is depending on the implementation. 

Hopefully fixes #1052, #1051, https://github.com/RiskioFr/oauth2-auth0/issues/28 https://github.com/Weble/ZohoClient/pull/34

cc @sandervanhooft @liayn

For libraries needing to add default scopes to the access request, I would suggest something like this in your own provider:

```php
public function getAccessToken($grant, array $options = [])
{
    if (empty($options['scope'])) {
        $options['scope'] = $this->getDefaultScopes();
    }
    
    return parent::getAccessToken($grant, $options);
}

```