### PR TITLE
Fix PHPDoc annotations of the getAccessToken method in AbstractProvider

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -615,7 +615,7 @@ abstract class AbstractProvider
     /**
      * Requests an access token using a specified grant and option set.
      *
-     * @param  mixed                $grant
+     * @param  AbstractGrant|string $grant
      * @param  array<string, mixed> $options
      * @return AccessTokenInterface
      * @throws IdentityProviderException


### PR DESCRIPTION
Fix PHPDoc annotations of the getAccessToken method in AbstractProvider to make it compatible with the verifyGrant method