### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^7.1 || >=8.0.0 <8.6.0",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.5.8 || ^7.4.5"
+        "guzzlehttp/guzzle": "^6.5.8 || ^7.8.2 || ^8.0",
+        "guzzlehttp/psr7": "^1.9.1 || ^2.6.3 || ^3.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.5",

--- a/test/src/Provider/AbstractProviderTest.php
+++ b/test/src/Provider/AbstractProviderTest.php
@@ -570,7 +570,7 @@ class AbstractProviderTest extends TestCase
         $provider = new MockProvider();
 
         $token = new AccessToken(['access_token' => 'abc', 'expires_in' => 3600]);
-        $request = $provider->getAuthenticatedRequest('get', 'https://api.example.com/v1/test', $token);
+        $request = $provider->getAuthenticatedRequest('GET', 'https://api.example.com/v1/test', $token);
 
         $stream = Mockery::mock(StreamInterface::class, [
             '__toString' => '{"example":"response"}',

--- a/test/src/Tool/RequestFactoryTest.php
+++ b/test/src/Tool/RequestFactoryTest.php
@@ -10,14 +10,14 @@ class RequestFactoryTest extends TestCase
 {
     public function testGetRequest()
     {
-        $method  = 'get';
+        $method  = 'GET';
         $uri     = '/test';
 
         $factory = new RequestFactory();
         $request = $factory->getRequest($method, $uri);
 
         $this->assertInstanceOf(RequestInterface::class, $request);
-        $this->assertSame(strtoupper($method), $request->getMethod());
+        $this->assertSame($method, $request->getMethod());
         $this->assertSame($uri, (string) $request->getUri());
 
         $headers         = ['X-Test' => 'Foo'];
@@ -33,14 +33,14 @@ class RequestFactoryTest extends TestCase
 
     public function testGetRequestWithOptions()
     {
-        $method  = 'head';
+        $method  = 'HEAD';
         $uri     = '/test/options';
 
         $factory = new RequestFactory();
         $request = $factory->getRequestWithOptions($method, $uri);
 
         $this->assertInstanceOf(RequestInterface::class, $request);
-        $this->assertSame(strtoupper($method), $request->getMethod());
+        $this->assertSame($method, $request->getMethod());
         $this->assertSame($uri, (string) $request->getUri());
 
         $options = [


### PR DESCRIPTION
Guzzle 8.0.0 was released on July 20th. Lots of people want to use it, and thus popular packages in the ecosystem like this one need to be updated to support it, so here I am, adding support. :)